### PR TITLE
v3.2.0: authoring, rendering and build tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,46 @@ jobs:
             exit 1
           fi
 
+      # A README that lists 23 tools while the package publishes 57 is how v2's docs ended up
+      # describing seven tools that did not exist. The catalogue is generated from the
+      # attributes, so the only thing that can drift is the prose — checked here rather than
+      # remembered.
+      - name: Every tool is documented
+        run: |
+          node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const root = 'jp.shiranui-isuzu.unity-mcp/Editor';
+
+            const walk = (dir, out = []) => {
+              for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+                const p = path.join(dir, e.name);
+                e.isDirectory() ? walk(p, out) : p.endsWith('.cs') && out.push(p);
+              }
+              return out;
+            };
+
+            const names = new Set();
+            for (const f of walk(root)) {
+              if (f.includes(path.sep + 'Tests' + path.sep)) continue;
+              const src = fs.readFileSync(f, 'utf8');
+              for (const m of src.matchAll(/McpTool\(\s*\"([a-z0-9_]+)\"/g)) names.add(m[1]);
+            }
+
+            let failed = false;
+            for (const readme of ['README.md', 'README.en.md']) {
+              const text = fs.readFileSync(readme, 'utf8');
+              const missing = [...names].filter(n => !text.includes('\`' + n + '\`')).sort();
+              if (missing.length) {
+                console.error(readme + ' does not mention: ' + missing.join(', '));
+                failed = true;
+              }
+            }
+
+            if (failed) process.exit(1);
+            console.log(names.size + ' tools, all documented in both READMEs');
+          "
+
       # Redistributing a binary without attributing it is a licensing problem, and the list
       # is exactly the kind of thing that goes stale silently when a dependency is swapped.
       - name: Every bundled assembly is attributed

--- a/README.en.md
+++ b/README.en.md
@@ -1,7 +1,7 @@
 # Unity MCP Integration Framework
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-3.1.0-brightgreen)
+![Version](https://img.shields.io/badge/version-3.2.0-brightgreen)
 ![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
 ![.NET](https://img.shields.io/badge/.NET-C%23_9.0-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)
@@ -142,32 +142,105 @@ MCP client (Claude)                        terminal / scripts
 
 ## Built-in tools
 
-### Published by the Editor (23)
+### Published by the Editor (57)
+
+**Looking**
 
 | Tool | Idempotency | Purpose |
 |---|---|---|
-| `execute_code` | unsafe | Compile and run a C# snippet |
+| `console_read_logs` | safe | Console entries |
+| `console_get_count` | safe | Error / warning / log counts |
+| `console_clear` | unsafe | Clear the console |
+| `editor_log_tail` | safe | `Editor.log` from disk (**works while the Editor is wedged**) |
 | `compile_status` | safe | Whether scripts are compiling, and whether the last compile succeeded |
 | `compile_request` | unsafe | Ask for a recompile |
 | `test_run` | unsafe | Start an EditMode or PlayMode test run |
 | `test_results` | safe | The current or most recent run (**readable while it runs**) |
-| `console_read_logs` | safe | Read console entries |
-| `console_get_count` | safe | Error / warning / log counts |
-| `console_clear` | unsafe | Clear the console |
-| `editor_log_tail` | safe | Read `Editor.log` from disk (**works while the Editor is wedged**) |
-| `scene_browse_hierarchy` | safe | Walk the scene hierarchy |
-| `inspect_read` / `inspect_list` | safe | Read and list serialized properties |
-| `inspect_write` | unsafe | Write a serialized property (collapses into one Undo step) |
+| `scene_browse_hierarchy` | safe | Walk the hierarchy. **Emits `path`**, which every editing tool takes |
+| `scene_list` | safe | Open scenes, and the scenes in the build settings |
+| `inspect_read` | safe | Read a serialized property |
+| `inspect_list` | safe | Discover property paths |
 | `play_mode_status` | safe | Playing / paused / compiling |
-| `play_mode_play` / `_stop` / `_pause` / `_unpause` / `_step` | unsafe | Play mode control |
-| `capture_screenshot` | safe | Game or Scene view, or an Editor panel |
-| `menu_execute` | unsafe | Invoke a menu item |
 | `project_assemblies` | safe | Loaded assemblies |
 | `project_packages` | safe | UPM packages |
+| `capture_screenshot` | safe | Game or Scene view, or an Editor panel. `save_path` writes it to disk |
+
+**Authoring** — every mutation collapses into one undo step.
+
+| Tool | Idempotency | Purpose |
+|---|---|---|
+| `gameobject_create` | unsafe | Create an object, optionally a primitive |
+| `gameobject_delete` | unsafe | Delete it (undoable) |
+| `gameobject_duplicate` | unsafe | Duplicate it |
+| `gameobject_reparent` | unsafe | Move it under another parent; world position kept by default |
+| `gameobject_set_transform` | unsafe | Position, rotation, scale. **Only the axes given** |
+| `gameobject_set_active` | unsafe | Activate or deactivate |
+| `gameobject_add_component` | unsafe | Add a component by type name |
+| `gameobject_remove_component` | unsafe | Remove one |
+| `inspect_write` | unsafe | Write a serialized property |
+| `asset_find` | safe | Search by type, name, folder or label |
+| `asset_info` | safe | Type, GUID, importer, dependencies |
+| `asset_create_folder` | unsafe | Create a folder and its parents, idempotently |
+| `asset_move` | unsafe | Move or rename, keeping the GUID |
+| `asset_delete` | unsafe | Delete. **Goes to the OS trash, so it is recoverable** |
+| `asset_reimport` | unsafe | Reimport |
+| `scene_open` | unsafe | Open a scene (refuses over unsaved changes) |
+| `scene_save` | unsafe | Save, or save as |
+| `scene_create` | unsafe | New scene |
+| `prefab_create` | unsafe | Save a scene object as a prefab |
+| `prefab_instantiate` | unsafe | Place a prefab |
+| `prefab_apply` | unsafe | Push instance overrides back into the asset |
+| `menu_execute` | unsafe | Invoke a menu item |
+| `play_mode_play` | unsafe | Enter play mode |
+| `play_mode_stop` | unsafe | Leave it |
+| `play_mode_pause` | unsafe | Pause |
+| `play_mode_unpause` | unsafe | Resume |
+| `play_mode_step` | unsafe | Step one frame |
+
+**Rendering and shaders**
+
+| Tool | Idempotency | Purpose |
+|---|---|---|
+| `render_compare` | safe | How two captures differ, **in numbers** (changed pixels, mean/max delta, bounding box, grid) |
+| `render_pipeline_info` | safe | Active pipeline, colour space, graphics API, quality level. **Reports the quality-level override too** |
+| `render_camera_info` | safe | Cameras with view, projection and **GPU projection** matrices |
+| `shader_errors` | safe | Shader compilation errors (**a broken shader renders magenta and says nothing**) |
+| `shader_info` | safe | Passes, properties, keyword space, render queue |
+| `material_read` | safe | A material's **current** values, keywords and render queue |
+| `material_set` | unsafe | Set a property, keyword or render queue |
+
+**Live state and GPU**
+
+| Tool | Idempotency | Purpose |
+|---|---|---|
+| `reflect_read` | safe | Read live state by type and member path, **private members included** |
+| `reflect_find_type` | safe | Find a loaded type by name |
+| `gpu_readback` | safe | Read a buffer or texture back and report **statistics, not contents** (range, mean, zero count, histogram) |
+| `execute_code` | unsafe | Compile and run a C# snippet (**the last resort when no tool reaches it**) |
+
+**Builds**
+
+| Tool | Idempotency | Purpose |
+|---|---|---|
+| `build_settings` | safe | Active target, the scenes in the build, whether the module is installed |
+| `build_player` | unsafe | Build a player. A cold build becomes a job; an incremental one answers inline |
+| `build_switch_target` | unsafe | Switch the active target (reimports assets) |
 
 Editor panel capture (`inspector`, `hierarchy`, `project`, `console`, `window:<title>`) is Windows-only; `game` and `scene` work everywhere.
 
 `test_run` and `test_results` appear only when `com.unity.test-framework` is present, which it is by default. They live in their own assembly constrained to `UNITY_INCLUDE_TESTS`, so a project without the framework loses those two tools rather than failing to compile the package.
+
+### Things that will bite otherwise
+
+- **The `path` an editing tool takes is the one `scene_browse_hierarchy` returns.** It resolves
+  inactive objects, and carries an index only where a sibling name repeats: `/Canvas/Button[1]/Text`.
+- **A scene edit made during Play Mode looks like it worked and is reverted when Play Mode stops.**
+  Those responses carry a `playModeWarning`. Asset edits made at the same moment do survive, so
+  they do not.
+- **Deletion is recoverable rather than gated.** Assets go to the OS trash and GameObjects go
+  through Undo, so neither asks for confirmation. Opening or replacing a scene over unsaved
+  changes *is* refused, because that is the one edit no undo stack can return.
+- **`execute_code` is not on the undo stack.** Use the authoring tools for authoring.
 
 ### Provided by the MCP server (3)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unity MCP 統合フレームワーク
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-3.1.0-brightgreen)
+![Version](https://img.shields.io/badge/version-3.2.0-brightgreen)
 ![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
 ![.NET](https://img.shields.io/badge/.NET-C%23_9.0-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)
@@ -137,32 +137,102 @@ MCP クライアント (Claude)                  ターミナル / スクリプ�
 
 ## 組み込みツール
 
-### Editor が公開するもの（23個）
+### Editor が公開するもの（57個）
+
+**診断（見る）**
 
 | ツール | 冪等性 | 用途 |
 |---|---|---|
-| `execute_code` | unsafe | C# スニペットのコンパイル・実行 |
-| `compile_status` | safe | コンパイル中か、直前のコンパイルが成功したか |
-| `compile_request` | unsafe | 再コンパイルを要求 |
-| `test_run` | unsafe | EditMode / PlayMode テストの実行を開始 |
-| `test_results` | safe | 実行中・直近のテスト結果（**実行中でも読める**） |
 | `console_read_logs` | safe | コンソールのエントリを読む |
 | `console_get_count` | safe | エラー / 警告 / ログの件数 |
 | `console_clear` | unsafe | コンソールをクリア |
 | `editor_log_tail` | safe | `Editor.log` を直接読む（**Editor が固まっていても動く**） |
-| `scene_browse_hierarchy` | safe | シーン階層の走査 |
-| `inspect_read` / `inspect_list` | safe | シリアライズプロパティの読み取り・一覧 |
-| `inspect_write` | unsafe | シリアライズプロパティの書き込み（Undo 1操作にまとまる） |
+| `compile_status` | safe | コンパイル中か、直前のコンパイルが成功したか |
+| `compile_request` | unsafe | 再コンパイルを要求 |
+| `test_run` | unsafe | EditMode / PlayMode テストの実行を開始 |
+| `test_results` | safe | 実行中・直近のテスト結果（**実行中でも読める**） |
+| `scene_browse_hierarchy` | safe | シーン階層の走査。**`path` を返す**ので編集系にそのまま渡せる |
+| `scene_list` | safe | 開いているシーンとビルド設定のシーン |
+| `inspect_read` | safe | シリアライズプロパティの読み取り |
+| `inspect_list` | safe | シリアライズプロパティの一覧 |
 | `play_mode_status` | safe | 再生中 / 一時停止中 / コンパイル中 |
-| `play_mode_play` / `_stop` / `_pause` / `_unpause` / `_step` | unsafe | Play mode 制御 |
-| `capture_screenshot` | safe | Game / Scene ビューや Editor パネルの画像 |
-| `menu_execute` | unsafe | メニュー項目の実行 |
 | `project_assemblies` | safe | ロード済みアセンブリ一覧 |
 | `project_packages` | safe | UPM パッケージ一覧 |
+| `capture_screenshot` | safe | Game / Scene ビューや Editor パネルの画像。`save_path` でファイル出力 |
+
+**オーサリング（作る・変える）** — すべて Undo 1操作にまとまります。
+
+| ツール | 冪等性 | 用途 |
+|---|---|---|
+| `gameobject_create` | unsafe | GameObject / プリミティブの生成 |
+| `gameobject_delete` | unsafe | 削除（Undo で戻せる） |
+| `gameobject_duplicate` | unsafe | 複製 |
+| `gameobject_reparent` | unsafe | 親子付け。ワールド位置は既定で維持 |
+| `gameobject_set_transform` | unsafe | 位置 / 回転 / スケール。**指定した軸だけ**変える |
+| `gameobject_set_active` | unsafe | 有効・無効の切り替え |
+| `gameobject_add_component` | unsafe | コンポーネント追加 |
+| `gameobject_remove_component` | unsafe | コンポーネント削除 |
+| `inspect_write` | unsafe | シリアライズプロパティの書き込み |
+| `asset_find` | safe | 型 / 名前 / フォルダ / ラベルでアセット検索 |
+| `asset_info` | safe | 型・GUID・importer・依存の詳細 |
+| `asset_create_folder` | unsafe | フォルダ作成（親も作る、冪等） |
+| `asset_move` | unsafe | 移動・リネーム（GUID を維持） |
+| `asset_delete` | unsafe | 削除。**OS のゴミ箱行きなので戻せる** |
+| `asset_reimport` | unsafe | 再インポート |
+| `scene_open` | unsafe | シーンを開く（未保存があれば拒否） |
+| `scene_save` | unsafe | 保存 / 別名保存 |
+| `scene_create` | unsafe | 新規シーン |
+| `prefab_create` | unsafe | シーンオブジェクトを Prefab 化 |
+| `prefab_instantiate` | unsafe | Prefab をシーンに配置 |
+| `prefab_apply` | unsafe | インスタンスのオーバーライドを Prefab へ適用 |
+| `menu_execute` | unsafe | メニュー項目の実行 |
+| `play_mode_play` | unsafe | 再生開始 |
+| `play_mode_stop` | unsafe | 停止 |
+| `play_mode_pause` | unsafe | 一時停止 |
+| `play_mode_unpause` | unsafe | 一時停止解除 |
+| `play_mode_step` | unsafe | 1フレーム進める |
+
+**描画・シェーダーのデバッグ**
+
+| ツール | 冪等性 | 用途 |
+|---|---|---|
+| `render_compare` | safe | 2枚のキャプチャの差を**数値で**返す（差分画素数・平均/最大デルタ・矩形・グリッド） |
+| `render_pipeline_info` | safe | 実効 RP、色空間、Graphics API、品質レベル。**Quality 側の RP 上書き**も併記 |
+| `render_camera_info` | safe | カメラと view / projection / **GPU projection** 行列 |
+| `shader_errors` | safe | シェーダーのコンパイルエラー（**黙って magenta になるので聞かないと分からない**） |
+| `shader_info` | safe | パス数、プロパティ、キーワード空間、render queue |
+| `material_read` | safe | マテリアルの**現在値**・有効キーワード・render queue |
+| `material_set` | unsafe | プロパティ / キーワード / render queue を変更 |
+
+**内部状態・GPU**
+
+| ツール | 冪等性 | 用途 |
+|---|---|---|
+| `reflect_read` | safe | 型とメンバーパスで**private を含む live な状態**を読む |
+| `reflect_find_type` | safe | ロード済み型の検索 |
+| `gpu_readback` | safe | バッファ / テクスチャを読み戻し、**中身でなく統計**（range / mean / zeroCount / histogram）を返す |
+| `execute_code` | unsafe | C# スニペットのコンパイル・実行（**専用ツールで届かないときの最後の手段**） |
+
+**ビルド**
+
+| ツール | 冪等性 | 用途 |
+|---|---|---|
+| `build_settings` | safe | 実効ビルドターゲット、ビルドに入るシーン、モジュールの有無 |
+| `build_player` | unsafe | プレイヤービルド。コールドは job、増分はインラインで返る |
+| `build_switch_target` | unsafe | ビルドターゲット切替（再インポートを伴う） |
 
 Editor パネルのキャプチャ（`inspector` / `hierarchy` / `project` / `console` / `window:<title>`）は Windows 限定です。`game` と `scene` は全プラットフォームで動きます。
 
 `test_run` / `test_results` は `com.unity.test-framework` が入っているときだけ現れます（Unity の既定パッケージなので通常は入っています）。専用のアセンブリに分けて `UNITY_INCLUDE_TESTS` で制約しているため、無い環境ではこの2つが一覧に出ないだけで、パッケージ全体は変わらず動きます。
+
+Unity Hub の操作（Editor やモジュールのインストール）は**あえて持ちません**。Hub 自身に CLI があるので、未インストールのビルドターゲットを指定したときに実行すべきコマンドを返します。
+
+### 知っておくと事故らないこと
+
+- **編集系ツールが受け取る `path` は `scene_browse_hierarchy` が返すものです。** 非アクティブなオブジェクトも解決でき、兄弟に同名がいるときだけ `/Canvas/Button[1]/Text` と添字が付きます。
+- **Play Mode 中のシーン編集は、成功したように見えて終了時に破棄されます。** その状況では応答に `playModeWarning` が付きます。アセットの変更は残るので、そちらには付きません。
+- **削除は確認を求めず、戻せるようにしてあります。** アセットは OS のゴミ箱へ、GameObject は Undo 経由です。ただし**未保存シーンへの上書きは拒否します**（これだけは Undo でも戻せないため）。
+- **`execute_code` は Undo に乗りません。** オーサリングは専用ツールを使ってください。
 
 ### MCP サーバが提供するもの（3個）
 

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## [3.2.0] - 2026-07-28
+
+Thirty-four tools, taking the count from 23 to 57. Until now the only way to
+change anything was `execute_code`, which is not on the undo stack, cannot
+declare its idempotency, and costs a round trip whenever a type name is guessed
+wrong. The rendering tools were chosen from what a real pipeline port actually
+did over and over, not from what looked useful.
+
+### Added
+- **Authoring.** `gameobject_create` / `_delete` / `_reparent` / `_duplicate` /
+  `_set_transform` / `_set_active` / `_add_component` / `_remove_component`,
+  `asset_find` / `_info` / `_create_folder` / `_move` / `_delete` / `_reimport`,
+  `scene_list` / `_open` / `_save` / `_create`, `prefab_create` / `_instantiate` /
+  `_apply`. Every mutation is on the undo stack, so one call is one Ctrl+Z.
+- **Builds.** `build_settings`, `build_player`, `build_switch_target`. A cold
+  build crosses the synchronous window and comes back as a job; an incremental
+  one answers inline. Unity Hub is deliberately not wrapped — an uninstalled
+  target says so and gives the Hub CLI command to run.
+- **Rendering and shaders.** `render_compare` reports how two captures differ in
+  numbers rather than pictures; `render_pipeline_info` reports both the graphics
+  and quality-level pipelines, because the second overrides the first;
+  `render_camera_info` exposes the view, projection and GPU projection matrices
+  so a value read off a screenshot can be checked against one computed on the
+  CPU. `shader_errors`, `shader_info`, `material_read`, `material_set`.
+- **Live state.** `reflect_read` and `reflect_find_type` read private members by
+  path; `gpu_readback` reads a buffer or texture back and reports its range,
+  mean, zero count and histogram rather than its contents.
+- `capture_screenshot` takes `save_path`, writing the PNG to disk and returning
+  the path. Comparing two inline captures costs most of a context window, which
+  defeats the point of having a comparison tool.
+- `scene_browse_hierarchy` emits `path`. Without it, a caller who had just
+  browsed the hierarchy had to guess at the identifier every other tool takes.
+- Scene edits made during Play Mode carry a `playModeWarning`. They succeed,
+  report truthfully, and are reverted on exit; asset edits made at the same
+  moment survive, and nothing distinguished them.
+
+### Fixed
+- **One tool call is one undo step.** `ToolInvoker` captured the undo group
+  without incrementing first, so every call in a session shared a group and each
+  collapse merged everything recorded since — a single Ctrl+Z reversed the whole
+  conversation. Present since 3.0.0, and invisible to any test that made one
+  call.
+- **Editor window captures were upside down.** Every Inspector, Hierarchy,
+  Project and Console screenshot came back mirrored top to bottom. The DIB was
+  requested top-down while `LoadRawTextureData` expects bottom-up.
+- `render_compare` leaked a texture per failed call when the second image was
+  missing, and reported a mismatched pair as `tool_failed` because it read the
+  sizes after destroying them.
+
+### Changed
+- Mutating a GameObject returns what the operation was about rather than
+  everything about the object. The transform comes back from the tools that
+  move it and the component list from the tools that change it.
+- Tests: 94 to 163. The new ones are shaped around repetition and boundaries,
+  because every defect above was correct once and wrong afterwards.
+
 ## [3.1.0] - 2026-07-28
 
 ### Added

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -35,7 +35,7 @@ namespace UnityMCP.Editor.Core
         /// remains only as the answer for an assembly that is not loaded from a package, and CI
         /// checks that it too stays in step.
         /// </remarks>
-        private const string FallbackVersion = "3.1.0";
+        private const string FallbackVersion = "3.2.0";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/ToolInvoker.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/ToolInvoker.cs
@@ -99,6 +99,12 @@ namespace UnityMCP.Editor.Core
 
             if (usingUndo)
             {
+                // Increment first. GetCurrentGroup returns whichever group is already open, so
+                // without this every call in a session captures the same index and each collapse
+                // merges everything recorded since — one Ctrl+Z then undoes the whole
+                // conversation instead of the last call. It looks correct until a second tool
+                // call happens, which is why a single-call test passed while this was wrong.
+                Undo.IncrementCurrentGroup();
                 undoGroup = Undo.GetCurrentGroup();
                 Undo.SetCurrentGroupName(descriptor.UndoGroup);
             }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/SceneHierarchy.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/SceneHierarchy.cs
@@ -178,6 +178,10 @@ namespace UnityMCP.Editor.Handlers
             return new JObject
             {
                 ["name"] = go.name,
+                // The identifier every authoring tool takes. Without it a caller who has just
+                // browsed the hierarchy has to guess at the path of the thing they are looking
+                // at, and guesses fail on any name that repeats among siblings.
+                ["path"] = UnityMCP.Editor.Tools.ObjectResolve.PathOf(go),
                 ["id"] = go.GetInstanceID(),
                 ["instanceId"] = go.GetInstanceID(),
                 ["active"] = go.activeSelf,

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/ScreenshotCapture.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/ScreenshotCapture.cs
@@ -32,6 +32,47 @@ namespace UnityMCP.Editor.Handlers
                 ["scene_view_window"] = "UnityEditor.SceneView",
             };
 
+        /// <summary>
+        /// Returns the capture as base64, or writes it to disk and returns the path instead.
+        /// </summary>
+        /// <remarks>
+        /// A 1024px PNG is a few hundred kilobytes of base64, and comparing two of them means
+        /// carrying both through the conversation. Writing to a file and passing paths to
+        /// render_compare keeps the pixels out of the transcript entirely, which is the whole
+        /// point of having a comparison tool rather than asking a model to eyeball two images.
+        /// </remarks>
+        private static JObject Deliver(byte[] pngBytes, string view, int width, int height, string savePath)
+        {
+            var result = new JObject
+            {
+                ["view"] = view,
+                ["width"] = width,
+                ["height"] = height,
+                ["bytes"] = pngBytes.Length,
+            };
+
+            if (string.IsNullOrWhiteSpace(savePath))
+            {
+                result["image"] = Convert.ToBase64String(pngBytes);
+                return result;
+            }
+
+            var full = System.IO.Path.GetFullPath(savePath);
+            var directory = System.IO.Path.GetDirectoryName(full);
+
+            if (!string.IsNullOrEmpty(directory))
+            {
+                System.IO.Directory.CreateDirectory(directory);
+            }
+
+            System.IO.File.WriteAllBytes(full, pngBytes);
+
+            result["path"] = full.Replace('\\', '/');
+            result["note"] = "Written to disk rather than returned inline. Pass this path to render_compare.";
+
+            return result;
+        }
+
         private const string WindowPrefix = "window:";
         private const uint SRCCOPY = 0x00CC0020;
         private const uint DIB_RGB_COLORS = 0;
@@ -42,17 +83,18 @@ namespace UnityMCP.Editor.Handlers
             var maxSize = parameters["maxSize"]?.Value<int>() ?? 1024;
             int? requestedWidth = parameters["width"]?.Value<int>();
             int? requestedHeight = parameters["height"]?.Value<int>();
+            var savePath = parameters["savePath"]?.ToString();
 
             // Editor panel views (or explicit window:<title>) route to desktop capture.
             if (IsEditorPanelView(view))
             {
-                return CaptureEditorWindow(view, maxSize, requestedWidth, requestedHeight);
+                return CaptureEditorWindow(view, maxSize, requestedWidth, requestedHeight, savePath);
             }
 
             // Camera-based views: "game" / "scene" only.
             if (view == "game" || view == "scene")
             {
-                return CaptureCameraView(view, maxSize, requestedWidth, requestedHeight);
+                return CaptureCameraView(view, maxSize, requestedWidth, requestedHeight, savePath);
             }
 
             // Unknown view name — surface as invalid_params so clients get a proper error envelope.
@@ -75,7 +117,7 @@ namespace UnityMCP.Editor.Handlers
         //  Camera-based capture (existing path, preserved)
         // ──────────────────────────────────────────────
 
-        private static JObject CaptureCameraView(string view, int maxSize, int? requestedWidth, int? requestedHeight)
+        private static JObject CaptureCameraView(string view, int maxSize, int? requestedWidth, int? requestedHeight, string savePath)
         {
             try
             {
@@ -159,16 +201,7 @@ namespace UnityMCP.Editor.Handlers
                     tex2d.Apply();
                     RenderTexture.active = previousActiveRT;
 
-                    var pngBytes = tex2d.EncodeToPNG();
-                    var base64 = Convert.ToBase64String(pngBytes);
-
-                    return new JObject
-                    {
-                        ["image"] = base64,
-                        ["view"] = view,
-                        ["width"] = captureWidth,
-                        ["height"] = captureHeight
-                    };
+                    return Deliver(tex2d.EncodeToPNG(), view, captureWidth, captureHeight, savePath);
                 }
                 finally
                 {
@@ -192,7 +225,7 @@ namespace UnityMCP.Editor.Handlers
         //  EditorWindow capture (desktop DC, Windows only)
         // ──────────────────────────────────────────────
 
-        private static JObject CaptureEditorWindow(string view, int maxSize, int? requestedWidth, int? requestedHeight)
+        private static JObject CaptureEditorWindow(string view, int maxSize, int? requestedWidth, int? requestedHeight, string savePath)
         {
 #if UNITY_EDITOR_WIN
             var window = ResolveEditorWindow(view);
@@ -252,17 +285,9 @@ namespace UnityMCP.Editor.Handlers
                     finalTex = resized;
                 }
 
-                var pngBytes = finalTex.EncodeToPNG();
-                var base64 = Convert.ToBase64String(pngBytes);
-
-                return new JObject
-                {
-                    ["image"] = base64,
-                    ["view"] = view,
-                    ["width"] = finalTex.width,
-                    ["height"] = finalTex.height,
-                    ["windowTitle"] = window.titleContent.text
-                };
+                var delivered = Deliver(finalTex.EncodeToPNG(), view, finalTex.width, finalTex.height, savePath);
+                delivered["windowTitle"] = window.titleContent.text;
+                return delivered;
             }
             finally
             {
@@ -428,7 +453,12 @@ namespace UnityMCP.Editor.Handlers
                     {
                         biSize = (uint)Marshal.SizeOf(typeof(BITMAPINFOHEADER)),
                         biWidth = physicalW,
-                        biHeight = -physicalH, // top-down DIB
+                        // Positive height asks GDI for a bottom-up DIB, which is the row order
+                        // LoadRawTextureData already expects: Unity's textures put v=0 at the
+                        // bottom. Asking for top-down here, as this did, produces a texture that
+                        // is upside down — captures came out mirrored top to bottom, readable
+                        // only as a mirror image, for every Editor panel.
+                        biHeight = physicalH,
                         biPlanes = 1,
                         biBitCount = 32,
                         biCompression = 0, // BI_RGB

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ObjectResolveTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ObjectResolveTests.cs
@@ -1,0 +1,278 @@
+using NUnit.Framework;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Tools;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// Resolving a hierarchy path to the object it names, and back.
+    /// </summary>
+    /// <remarks>
+    /// The two properties worth guarding are the ones <c>GameObject.Find</c> does not have:
+    /// inactive objects resolve, and a name that repeats among siblings still identifies exactly
+    /// one object. Both matter because every authoring tool addresses its target this way, and a
+    /// path that silently lands on the wrong object edits the wrong thing.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ObjectResolveTests
+    {
+        private GameObject root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.root = new GameObject("ResolveRoot");
+            var child = new GameObject("Child");
+            child.transform.SetParent(this.root.transform);
+
+            var twinA = new GameObject("Twin");
+            twinA.transform.SetParent(this.root.transform);
+            var twinB = new GameObject("Twin");
+            twinB.transform.SetParent(this.root.transform);
+
+            var deep = new GameObject("Deep");
+            deep.transform.SetParent(twinB.transform);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (this.root != null)
+            {
+                Object.DestroyImmediate(this.root);
+            }
+        }
+
+        [Test]
+        public void ResolvesARootByPath()
+        {
+            Assert.That(ObjectResolve.Object("/ResolveRoot", null).name, Is.EqualTo("ResolveRoot"));
+        }
+
+        [Test]
+        public void ALeadingSlashIsOptional()
+        {
+            Assert.That(ObjectResolve.Object("ResolveRoot/Child", null).name, Is.EqualTo("Child"));
+        }
+
+        [Test]
+        public void ResolvesAnInactiveObject()
+        {
+            var child = ObjectResolve.Object("/ResolveRoot/Child", null);
+            child.SetActive(false);
+
+            Assert.That(ObjectResolve.Object("/ResolveRoot/Child", null), Is.SameAs(child),
+                "GameObject.Find cannot see this, which is why the walk exists");
+        }
+
+        [Test]
+        public void ResolvesUnderAnInactiveParent()
+        {
+            this.root.SetActive(false);
+
+            Assert.That(ObjectResolve.Object("/ResolveRoot/Twin[1]/Deep", null).name, Is.EqualTo("Deep"));
+        }
+
+        [Test]
+        public void DuplicateSiblingsGetAnIndexedPath()
+        {
+            var twins = this.root.transform;
+            var first = twins.Find("Twin").gameObject;
+
+            Assert.That(ObjectResolve.PathOf(first), Is.EqualTo("/ResolveRoot/Twin[0]"));
+        }
+
+        [Test]
+        public void AUniqueNameGetsNoIndex()
+        {
+            var child = ObjectResolve.Object("/ResolveRoot/Child", null);
+
+            Assert.That(ObjectResolve.PathOf(child), Is.EqualTo("/ResolveRoot/Child"));
+        }
+
+        [Test]
+        public void AnIndexedPathRoundTrips()
+        {
+            var second = ObjectResolve.Object("/ResolveRoot/Twin[1]", null);
+            var path = ObjectResolve.PathOf(second);
+
+            Assert.That(path, Is.EqualTo("/ResolveRoot/Twin[1]"));
+            Assert.That(ObjectResolve.Object(path, null), Is.SameAs(second));
+        }
+
+        [Test]
+        public void AnUnindexedPathTakesTheFirstMatch()
+        {
+            Assert.That(
+                ObjectResolve.Object("/ResolveRoot/Twin", null),
+                Is.SameAs(ObjectResolve.Object("/ResolveRoot/Twin[0]", null)));
+        }
+
+        [Test]
+        public void AnInstanceIdWins()
+        {
+            var child = ObjectResolve.Object("/ResolveRoot/Child", null);
+
+            Assert.That(ObjectResolve.Object(null, child.GetInstanceID()), Is.SameAs(child));
+        }
+
+        [Test]
+        public void AMissingSegmentReportsWhatIsThere()
+        {
+            var ex = Assert.Throws<McpToolException>(
+                () => ObjectResolve.Object("/ResolveRoot/Nope", null));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+            Assert.That(ex.Message, Does.Contain("Child"), "the message should list the real children");
+            Assert.That(ex.Message, Does.Contain("Twin"));
+        }
+
+        [Test]
+        public void NeitherPathNorIdIsRefused()
+        {
+            var ex = Assert.Throws<McpToolException>(() => ObjectResolve.Object(null, null));
+
+            Assert.That(ex.Code, Is.EqualTo("invalid_params"));
+        }
+
+        [Test]
+        public void AStaleInstanceIdIsExplained()
+        {
+            var ex = Assert.Throws<McpToolException>(() => ObjectResolve.Object(null, -987654321));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+            Assert.That(ex.Message, Does.Contain("domain reload"));
+        }
+
+        // ── repetition ──
+
+        [Test]
+        public void CreatingASecondSiblingChangesTheFirstOnesPath()
+        {
+            var solo = new GameObject("Solo");
+            solo.transform.SetParent(this.root.transform);
+
+            Assert.That(ObjectResolve.PathOf(solo), Is.EqualTo("/ResolveRoot/Solo"));
+
+            var twin = new GameObject("Solo");
+            twin.transform.SetParent(this.root.transform);
+
+            // Worth pinning down rather than discovering later: an unindexed path held from
+            // before the second object existed still resolves, and still resolves to the first.
+            Assert.That(ObjectResolve.PathOf(solo), Is.EqualTo("/ResolveRoot/Solo[0]"));
+            Assert.That(ObjectResolve.Object("/ResolveRoot/Solo", null), Is.SameAs(solo));
+        }
+
+        [Test]
+        public void ResolvingRepeatedlyGivesTheSameObject()
+        {
+            var first = ObjectResolve.Object("/ResolveRoot/Twin[1]", null);
+
+            for (var i = 0; i < 5; i++)
+            {
+                Assert.That(ObjectResolve.Object("/ResolveRoot/Twin[1]", null), Is.SameAs(first));
+            }
+        }
+
+        [Test]
+        public void APathSurvivesTheObjectBeingDeactivatedAndReactivated()
+        {
+            var child = ObjectResolve.Object("/ResolveRoot/Child", null);
+
+            for (var i = 0; i < 3; i++)
+            {
+                child.SetActive(false);
+                Assert.That(ObjectResolve.Object("/ResolveRoot/Child", null), Is.SameAs(child));
+                child.SetActive(true);
+                Assert.That(ObjectResolve.Object("/ResolveRoot/Child", null), Is.SameAs(child));
+            }
+        }
+
+        [Test]
+        public void RenamingInvalidatesTheOldPathAndTheNewOneWorks()
+        {
+            var child = ObjectResolve.Object("/ResolveRoot/Child", null);
+            child.name = "Renamed";
+
+            Assert.Throws<McpToolException>(() => ObjectResolve.Object("/ResolveRoot/Child", null));
+            Assert.That(ObjectResolve.Object("/ResolveRoot/Renamed", null), Is.SameAs(child));
+        }
+
+        // ── boundaries ──
+
+        [Test]
+        public void AnEmptyPathIsRefused()
+        {
+            Assert.That(Assert.Throws<McpToolException>(() => ObjectResolve.Object("", null)).Code,
+                Is.EqualTo("invalid_params"));
+            Assert.That(Assert.Throws<McpToolException>(() => ObjectResolve.Object("   ", null)).Code,
+                Is.EqualTo("invalid_params"));
+        }
+
+        [Test]
+        public void RedundantSlashesAreIgnored()
+        {
+            Assert.That(ObjectResolve.Object("//ResolveRoot///Child/", null).name, Is.EqualTo("Child"));
+        }
+
+        [Test]
+        public void AnIndexOfZeroIsTheSameAsNoIndex()
+        {
+            Assert.That(
+                ObjectResolve.Object("/ResolveRoot/Child[0]", null),
+                Is.SameAs(ObjectResolve.Object("/ResolveRoot/Child", null)));
+        }
+
+        [Test]
+        public void AnIndexPastTheLastDuplicateDoesNotResolve()
+        {
+            Assert.That(Assert.Throws<McpToolException>(
+                () => ObjectResolve.Object("/ResolveRoot/Twin[2]", null)).Code, Is.EqualTo("not_found"));
+        }
+
+        [Test]
+        public void DeepNestingRoundTrips()
+        {
+            var current = this.root.transform;
+
+            for (var i = 0; i < 12; i++)
+            {
+                var next = new GameObject("L" + i);
+                next.transform.SetParent(current);
+                current = next.transform;
+            }
+
+            var path = ObjectResolve.PathOf(current.gameObject);
+
+            Assert.That(path, Is.EqualTo("/ResolveRoot/L0/L1/L2/L3/L4/L5/L6/L7/L8/L9/L10/L11"));
+            Assert.That(ObjectResolve.Object(path, null), Is.SameAs(current.gameObject));
+        }
+
+        [Test]
+        public void PathOfNullIsNullRatherThanAThrow()
+        {
+            Assert.That(ObjectResolve.PathOf(null), Is.Null);
+        }
+
+        [Test]
+        public void FindsAComponentByShortName()
+        {
+            var child = ObjectResolve.Object("/ResolveRoot/Child", null);
+
+            Assert.That(ObjectResolve.Component(child, "Transform"), Is.SameAs(child.transform));
+        }
+
+        [Test]
+        public void AMissingComponentListsWhatThereIs()
+        {
+            var child = ObjectResolve.Object("/ResolveRoot/Child", null);
+            var ex = Assert.Throws<McpToolException>(() => ObjectResolve.Component(child, "Rigidbody"));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+            Assert.That(ex.Message, Does.Contain("Transform"));
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ObjectResolveTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ObjectResolveTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 15bafe2d3d4e816499627aab50cddf72

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ReflectToolsTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ReflectToolsTests.cs
@@ -1,0 +1,298 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Tools;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// Path parsing, member walking and the limits on what comes back.
+    /// </summary>
+    /// <remarks>
+    /// The limits are the part worth guarding. A reflection reader that follows every reference
+    /// as far as it goes will happily serialise an entire scene graph into one response, and a
+    /// truncation that is not announced is indistinguishable from an empty collection.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ReflectToolsTests
+    {
+        internal sealed class Inner
+        {
+            public int Depth2 = 42;
+        }
+
+        internal sealed class Outer
+        {
+            public Inner Nested = new Inner();
+
+            public int Number = 7;
+        }
+
+        internal static class Probe
+        {
+            public static int Value = 5;
+
+            public static string[] Names = { "a", "b", "c" };
+
+            public static Dictionary<string, int> Map = new Dictionary<string, int> { ["x"] = 1, ["y"] = 2 };
+
+            public static Outer Tree = new Outer();
+
+            public static Vector3 Position = new Vector3(1f, 2f, 3f);
+
+            public static object Nothing;
+        }
+
+        private static JToken Read(string path, int depth = 2, int maxItems = 20)
+        {
+            var value = ReflectTools.ResolvePath(path, out _, out _);
+            return ReflectTools.Serialize(value, depth, maxItems);
+        }
+
+        [Test]
+        public void SplitsSegmentsAndIndexers()
+        {
+            var segments = ReflectTools.SplitPath("A.B/c/d[3]/e[\"key\"]");
+
+            Assert.That(segments.Select(s => s.Name), Is.EqualTo(new[] { "A.B", "c", "d", "e" }));
+            Assert.That(segments[2].Index, Is.EqualTo("3"));
+            Assert.That(segments[3].Index, Is.EqualTo("key"), "quotes should be stripped");
+            Assert.That(segments[1].Index, Is.Null);
+        }
+
+        [Test]
+        public void ReadsAStaticField()
+        {
+            Assert.That(Read($"{typeof(Probe).FullName}/Value").Value<int>(), Is.EqualTo(5));
+        }
+
+        [Test]
+        public void IndexesAnArray()
+        {
+            Assert.That(Read($"{typeof(Probe).FullName}/Names[1]").Value<string>(), Is.EqualTo("b"));
+        }
+
+        [Test]
+        public void IndexesADictionaryByKey()
+        {
+            Assert.That(Read($"{typeof(Probe).FullName}/Map[\"y\"]").Value<int>(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void AMissingDictionaryKeyListsTheKeys()
+        {
+            var ex = Assert.Throws<McpToolException>(
+                () => ReflectTools.ResolvePath($"{typeof(Probe).FullName}/Map[\"z\"]", out _, out _));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+            Assert.That(ex.Message, Does.Contain("x"));
+        }
+
+        [Test]
+        public void AnIndexPastTheEndIsRefused()
+        {
+            var ex = Assert.Throws<McpToolException>(
+                () => ReflectTools.ResolvePath($"{typeof(Probe).FullName}/Names[9]", out _, out _));
+
+            Assert.That(ex.Code, Is.EqualTo("invalid_params"));
+        }
+
+        [Test]
+        public void AnUnknownMemberListsWhatIsAvailable()
+        {
+            var ex = Assert.Throws<McpToolException>(
+                () => ReflectTools.ResolvePath($"{typeof(Probe).FullName}/NotThere", out _, out _));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+            Assert.That(ex.Message, Does.Contain("Value"));
+        }
+
+        [Test]
+        public void AnUnknownTypeIsReported()
+        {
+            var ex = Assert.Throws<McpToolException>(
+                () => ReflectTools.ResolvePath("No.Such.Type/x", out _, out _));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+        }
+
+        [Test]
+        public void WalkingThroughNullExplainsWhere()
+        {
+            var ex = Assert.Throws<McpToolException>(
+                () => ReflectTools.ResolvePath($"{typeof(Probe).FullName}/Nothing/anything", out _, out _));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+            Assert.That(ex.Message, Does.Contain("Nothing"));
+        }
+
+        [Test]
+        public void VectorsSerialiseAsComponents()
+        {
+            var v = Read($"{typeof(Probe).FullName}/Position");
+
+            Assert.That(v["x"].Value<float>(), Is.EqualTo(1f));
+            Assert.That(v["z"].Value<float>(), Is.EqualTo(3f));
+        }
+
+        [Test]
+        public void DepthIsAnnouncedWhenItRunsOut()
+        {
+            var shallow = Read($"{typeof(Probe).FullName}/Tree", depth: 1);
+
+            Assert.That(shallow["Number"].Value<int>(), Is.EqualTo(7));
+            Assert.That(shallow["Nested"]["truncated"].Value<string>(), Is.EqualTo("depth"),
+                "a value cut off by the depth limit must say so rather than read as empty");
+        }
+
+        [Test]
+        public void DepthReachesNestedValuesWhenAllowed()
+        {
+            var deep = Read($"{typeof(Probe).FullName}/Tree", depth: 3);
+
+            Assert.That(deep["Nested"]["Depth2"].Value<int>(), Is.EqualTo(42));
+        }
+
+        [Test]
+        public void CollectionTruncationIsAnnounced()
+        {
+            var limited = Read($"{typeof(Probe).FullName}/Names", maxItems: 2);
+
+            Assert.That(limited["items"].Count(), Is.EqualTo(2));
+            Assert.That(limited["truncated"].Value<string>(), Does.Contain("2"));
+        }
+
+        [Test]
+        public void AnUntruncatedCollectionIsAPlainArray()
+        {
+            var full = Read($"{typeof(Probe).FullName}/Names", maxItems: 10);
+
+            Assert.That(full, Is.TypeOf<JArray>());
+            Assert.That(full.Count(), Is.EqualTo(3));
+        }
+
+        // ── repetition ──
+
+        [Test]
+        public void RepeatedReadsAreStable()
+        {
+            var first = Read($"{typeof(Probe).FullName}/Tree", depth: 3).ToString();
+
+            for (var i = 0; i < 5; i++)
+            {
+                Assert.That(Read($"{typeof(Probe).FullName}/Tree", depth: 3).ToString(), Is.EqualTo(first));
+            }
+        }
+
+        [Test]
+        public void ReadingDoesNotChangeWhatIsBeingRead()
+        {
+            var before = Probe.Value;
+            var names = Probe.Names.ToArray();
+
+            for (var i = 0; i < 3; i++)
+            {
+                Read($"{typeof(Probe).FullName}/Value");
+                Read($"{typeof(Probe).FullName}/Names");
+                Read($"{typeof(Probe).FullName}/Map");
+            }
+
+            Assert.That(Probe.Value, Is.EqualTo(before));
+            Assert.That(Probe.Names, Is.EqualTo(names));
+        }
+
+        [Test]
+        public void RepeatedFailuresKeepFailingTheSameWay()
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                var ex = Assert.Throws<McpToolException>(
+                    () => ReflectTools.ResolvePath($"{typeof(Probe).FullName}/NotThere", out _, out _));
+
+                Assert.That(ex.Code, Is.EqualTo("not_found"));
+            }
+        }
+
+        // ── boundaries ──
+
+        [Test]
+        public void DepthZeroStillNamesTheType()
+        {
+            var v = Read($"{typeof(Probe).FullName}/Tree", depth: 0);
+
+            Assert.That(v["truncated"].Value<string>(), Is.EqualTo("depth"));
+            Assert.That(v["type"].Value<string>(), Does.Contain("Outer"));
+        }
+
+        [Test]
+        public void MaxItemsZeroReturnsNoneAndSaysSo()
+        {
+            var v = Read($"{typeof(Probe).FullName}/Names", maxItems: 0);
+
+            Assert.That(v["items"].Count(), Is.EqualTo(0));
+            Assert.That(v["truncated"], Is.Not.Null);
+        }
+
+        [Test]
+        public void MaxItemsExactlyAtTheCountIsNotTruncated()
+        {
+            var v = Read($"{typeof(Probe).FullName}/Names", maxItems: 3);
+
+            Assert.That(v, Is.TypeOf<JArray>(), "three of three is the whole thing");
+        }
+
+        [Test]
+        public void ATrailingSlashIsIgnored()
+        {
+            Assert.That(Read($"{typeof(Probe).FullName}/Value/").Value<int>(), Is.EqualTo(5));
+        }
+
+        [Test]
+        public void AnUnclosedIndexerIsTreatedAsPartOfTheName()
+        {
+            // Better to fail on the member name than to guess at what was meant.
+            var ex = Assert.Throws<McpToolException>(
+                () => ReflectTools.ResolvePath($"{typeof(Probe).FullName}/Names[1", out _, out _));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+        }
+
+        [Test]
+        public void AnEmptyPathIsRefused()
+        {
+            Assert.That(Assert.Throws<McpToolException>(
+                () => ReflectTools.SplitPath("///")).Code, Is.EqualTo("invalid_params"));
+        }
+
+        [Test]
+        public void TheTypeAloneIsAValidPath()
+        {
+            var value = ReflectTools.ResolvePath(typeof(Probe).FullName, out var type, out _);
+
+            Assert.That(value, Is.Null, "no member was named, so there is no value");
+            Assert.That(type, Is.EqualTo(typeof(Probe)));
+        }
+
+        [Test]
+        public void NullSerialisesAsNullRatherThanBeingDropped()
+        {
+            Assert.That(Read($"{typeof(Probe).FullName}/Nothing").Type, Is.EqualTo(JTokenType.Null));
+        }
+
+        [Test]
+        public void MemberNamesIncludeNonPublicOnes()
+        {
+            var names = ReflectTools.MemberNames(typeof(Probe)).ToArray();
+
+            Assert.That(names, Does.Contain("Value"));
+            Assert.That(names, Does.Contain("Map"));
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ReflectToolsTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ReflectToolsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d89c60dadc81884d96b309e2e81e37f

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/RenderCompareTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/RenderCompareTests.cs
@@ -1,0 +1,283 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Tools;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// Difference statistics, their boundaries, and what repeating a call costs.
+    /// </summary>
+    /// <remarks>
+    /// The numbers here are chosen by the test and written into the images, so a wrong answer
+    /// cannot agree with a wrong expectation. The repetition cases exist because the defects
+    /// this file was written alongside were all of that shape: correct once, wrong or leaking
+    /// the second time.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class RenderCompareTests
+    {
+        private string directory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.directory = Path.Combine(Path.GetTempPath(), "unity-mcp-compare-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(this.directory);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(this.directory))
+            {
+                Directory.Delete(this.directory, true);
+            }
+        }
+
+        /// <summary>Writes a solid image, optionally with one differently coloured rectangle.</summary>
+        private string Png(string name, int width, int height, Color32 fill, RectInt? patch = null, Color32 patchColour = default)
+        {
+            var texture = new Texture2D(width, height, TextureFormat.RGBA32, false);
+
+            try
+            {
+                var pixels = Enumerable.Repeat(fill, width * height).ToArray();
+
+                if (patch.HasValue)
+                {
+                    var r = patch.Value;
+
+                    for (var y = r.yMin; y < r.yMax; y++)
+                    {
+                        for (var x = r.xMin; x < r.xMax; x++)
+                        {
+                            pixels[y * width + x] = patchColour;
+                        }
+                    }
+                }
+
+                texture.SetPixels32(pixels);
+                texture.Apply();
+
+                var path = Path.Combine(this.directory, name);
+                File.WriteAllBytes(path, texture.EncodeToPNG());
+                return path;
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(texture);
+            }
+        }
+
+        private static int LiveTextureCount()
+        {
+            return UnityEngine.Resources.FindObjectsOfTypeAll<Texture2D>().Length;
+        }
+
+        [Test]
+        public void IdenticalImagesReportNoChange()
+        {
+            var a = this.Png("a.png", 16, 8, new Color32(10, 20, 30, 255));
+            var b = this.Png("b.png", 16, 8, new Color32(10, 20, 30, 255));
+
+            var result = RenderTools.Compare(a, b);
+
+            Assert.That(result["identical"].Value<bool>(), Is.True);
+            Assert.That(result["changedPixels"].Value<long>(), Is.EqualTo(0));
+            Assert.That(result["maxDelta"].Value<int>(), Is.EqualTo(0));
+            Assert.That(result["boundingBox"], Is.Null, "there is no box when nothing moved");
+        }
+
+        [Test]
+        public void CountsAndLocatesAKnownRectangle()
+        {
+            var a = this.Png("a.png", 20, 10, new Color32(10, 20, 30, 255));
+            var b = this.Png("b.png", 20, 10, new Color32(10, 20, 30, 255),
+                new RectInt(4, 2, 5, 3), new Color32(10, 60, 30, 255));
+
+            var result = RenderTools.Compare(a, b);
+
+            Assert.That(result["changedPixels"].Value<long>(), Is.EqualTo(5 * 3));
+            Assert.That(result["meanDelta"].Value<double>(), Is.EqualTo(40d));
+            Assert.That(result["maxDelta"].Value<int>(), Is.EqualTo(40));
+            Assert.That(result["boundingBox"]["x"].Value<int>(), Is.EqualTo(4));
+            Assert.That(result["boundingBox"]["y"].Value<int>(), Is.EqualTo(2));
+            Assert.That(result["boundingBox"]["width"].Value<int>(), Is.EqualTo(5));
+            Assert.That(result["boundingBox"]["height"].Value<int>(), Is.EqualTo(3));
+        }
+
+        [Test]
+        public void TheDeltaIsThePerChannelMaximum()
+        {
+            var a = this.Png("a.png", 4, 4, new Color32(10, 10, 10, 255));
+            var b = this.Png("b.png", 4, 4, new Color32(20, 15, 12, 255));
+
+            var result = RenderTools.Compare(a, b);
+
+            Assert.That(result["maxDelta"].Value<int>(), Is.EqualTo(10), "not the sum of the channels");
+        }
+
+        // ── boundaries ──
+
+        [Test]
+        public void AThresholdIsInclusive()
+        {
+            var a = this.Png("a.png", 4, 4, new Color32(10, 10, 10, 255));
+            var b = this.Png("b.png", 4, 4, new Color32(13, 10, 10, 255));
+
+            Assert.That(RenderTools.Compare(a, b, threshold: 3)["changedPixels"].Value<long>(), Is.EqualTo(0),
+                "a delta equal to the threshold is not a change");
+            Assert.That(RenderTools.Compare(a, b, threshold: 2)["changedPixels"].Value<long>(), Is.EqualTo(16));
+        }
+
+        [Test]
+        public void AThresholdAboveEveryPossibleDeltaFindsNothing()
+        {
+            var a = this.Png("a.png", 4, 4, new Color32(0, 0, 0, 255));
+            var b = this.Png("b.png", 4, 4, new Color32(255, 255, 255, 255));
+
+            Assert.That(RenderTools.Compare(a, b, threshold: 255)["identical"].Value<bool>(), Is.True);
+            Assert.That(RenderTools.Compare(a, b, threshold: 254)["changedPixels"].Value<long>(), Is.EqualTo(16));
+        }
+
+        [Test]
+        public void ASinglePixelImageWorks()
+        {
+            var a = this.Png("a.png", 1, 1, new Color32(0, 0, 0, 255));
+            var b = this.Png("b.png", 1, 1, new Color32(9, 0, 0, 255));
+
+            var result = RenderTools.Compare(a, b);
+
+            Assert.That(result["totalPixels"].Value<long>(), Is.EqualTo(1));
+            Assert.That(result["changedPixels"].Value<long>(), Is.EqualTo(1));
+            Assert.That(result["boundingBox"]["width"].Value<int>(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TheGridIsClampedRatherThanTrusted()
+        {
+            var a = this.Png("a.png", 8, 8, new Color32(0, 0, 0, 255));
+            var b = this.Png("b.png", 8, 8, new Color32(9, 0, 0, 255));
+
+            Assert.That(RenderTools.Compare(a, b, grid: 0)["gridChangedRatio"].Count(), Is.EqualTo(1),
+                "a grid below one collapses to a single cell rather than dividing by zero");
+            Assert.That(RenderTools.Compare(a, b, grid: 1000)["gridChangedRatio"].Count(), Is.EqualTo(32),
+                "and an absurd grid is capped");
+        }
+
+        [Test]
+        public void EveryCellIsFullWhenEverythingChanged()
+        {
+            var a = this.Png("a.png", 8, 8, new Color32(0, 0, 0, 255));
+            var b = this.Png("b.png", 8, 8, new Color32(90, 0, 0, 255));
+
+            var grid = RenderTools.Compare(a, b, grid: 2)["gridChangedRatio"];
+
+            Assert.That(grid.SelectMany(row => row).Select(v => v.Value<double>()),
+                Is.All.EqualTo(1d));
+        }
+
+        [Test]
+        public void MismatchedSizesAreRefusedWithTheSizes()
+        {
+            var a = this.Png("a.png", 8, 8, new Color32(0, 0, 0, 255));
+            var b = this.Png("b.png", 4, 8, new Color32(0, 0, 0, 255));
+
+            var ex = Assert.Throws<McpToolException>(() => RenderTools.Compare(a, b));
+
+            Assert.That(ex.Code, Is.EqualTo("invalid_params"));
+            Assert.That(ex.Message, Does.Contain("8x8"), "the refusal has to name the sizes it saw");
+            Assert.That(ex.Message, Does.Contain("4x8"));
+        }
+
+        [Test]
+        public void AMissingFileIsReported()
+        {
+            var a = this.Png("a.png", 4, 4, new Color32(0, 0, 0, 255));
+            var ex = Assert.Throws<McpToolException>(
+                () => RenderTools.Compare(a, Path.Combine(this.directory, "absent.png")));
+
+            Assert.That(ex.Code, Is.EqualTo("not_found"));
+        }
+
+        // ── repetition ──
+
+        [Test]
+        public void RepeatedCallsGiveTheSameAnswer()
+        {
+            var a = this.Png("a.png", 12, 6, new Color32(10, 20, 30, 255));
+            var b = this.Png("b.png", 12, 6, new Color32(10, 20, 30, 255),
+                new RectInt(1, 1, 3, 2), new Color32(10, 70, 30, 255));
+
+            var first = RenderTools.Compare(a, b).ToString();
+
+            for (var i = 0; i < 4; i++)
+            {
+                Assert.That(RenderTools.Compare(a, b).ToString(), Is.EqualTo(first));
+            }
+        }
+
+        [Test]
+        public void RepeatedCallsDoNotAccumulateTextures()
+        {
+            var a = this.Png("a.png", 12, 6, new Color32(10, 20, 30, 255));
+            var b = this.Png("b.png", 12, 6, new Color32(11, 20, 30, 255));
+
+            RenderTools.Compare(a, b);
+            var baseline = LiveTextureCount();
+
+            for (var i = 0; i < 10; i++)
+            {
+                RenderTools.Compare(a, b);
+            }
+
+            Assert.That(LiveTextureCount(), Is.EqualTo(baseline),
+                "each call loads two textures and must destroy both");
+        }
+
+        [Test]
+        public void RepeatedFailuresDoNotAccumulateTextures()
+        {
+            // The first image loads, the second does not. Everything already loaded still has to
+            // be released on the way out — this leaked one texture per attempt.
+            var a = this.Png("a.png", 12, 6, new Color32(10, 20, 30, 255));
+            var absent = Path.Combine(this.directory, "absent.png");
+
+            Assert.Throws<McpToolException>(() => RenderTools.Compare(a, absent));
+            var baseline = LiveTextureCount();
+
+            for (var i = 0; i < 10; i++)
+            {
+                Assert.Throws<McpToolException>(() => RenderTools.Compare(a, absent));
+            }
+
+            Assert.That(LiveTextureCount(), Is.EqualTo(baseline));
+        }
+
+        [Test]
+        public void RepeatedSizeMismatchesDoNotAccumulateTextures()
+        {
+            var a = this.Png("a.png", 8, 8, new Color32(0, 0, 0, 255));
+            var b = this.Png("b.png", 4, 4, new Color32(0, 0, 0, 255));
+
+            Assert.Throws<McpToolException>(() => RenderTools.Compare(a, b));
+            var baseline = LiveTextureCount();
+
+            for (var i = 0; i < 10; i++)
+            {
+                Assert.Throws<McpToolException>(() => RenderTools.Compare(a, b));
+            }
+
+            Assert.That(LiveTextureCount(), Is.EqualTo(baseline));
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/RenderCompareTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/RenderCompareTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: caa65d058be6fba41acb6074d5c57a97

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/UndoGroupingTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/UndoGroupingTests.cs
@@ -1,0 +1,160 @@
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using NUnit.Framework;
+
+using UnityEditor;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// One tool call must be one undo step.
+    /// </summary>
+    /// <remarks>
+    /// This exists because the opposite shipped. <see cref="ToolInvoker"/> captured
+    /// <c>Undo.GetCurrentGroup()</c> without incrementing first, so every call in a session
+    /// shared a group index and each collapse merged everything recorded since — a single
+    /// Ctrl+Z reversed the whole conversation. Every existing invoker test passed throughout,
+    /// because a single call cannot observe it. The distinguishing case is two calls, so that
+    /// is what is asserted here.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class UndoGroupingTests
+    {
+        private static class Tools
+        {
+            [McpTool("t_undo_move", "Moves an object, on the undo stack.",
+                     Idempotency = McpIdempotency.Unsafe, UndoGroup = "Test Move")]
+            public static float Move(
+                [McpArg("name", "Object name")] string name,
+                [McpArg("x", "New x")] float x)
+            {
+                var go = GameObject.Find(name);
+                Undo.RecordObject(go.transform, "Test Move");
+                go.transform.localPosition = new Vector3(x, 0f, 0f);
+                return go.transform.localPosition.x;
+            }
+
+            [McpTool("t_undo_none", "Moves an object without declaring an undo group.",
+                     Idempotency = McpIdempotency.Unsafe)]
+            public static float MoveUngrouped(
+                [McpArg("name", "Object name")] string name,
+                [McpArg("x", "New x")] float x)
+            {
+                var go = GameObject.Find(name);
+                go.transform.localPosition = new Vector3(x, 0f, 0f);
+                return go.transform.localPosition.x;
+            }
+        }
+
+        private ToolCatalog catalog;
+
+        private GameObject target;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.catalog = ToolCatalog.BuildFromTypes(new[] { typeof(Tools) });
+
+            Undo.ClearAll();
+            this.target = new GameObject("UndoGroupingTarget");
+            Undo.RegisterCreatedObjectUndo(this.target, "create target");
+            Undo.IncrementCurrentGroup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (this.target != null)
+            {
+                Object.DestroyImmediate(this.target);
+            }
+
+            Undo.ClearAll();
+        }
+
+        private void Move(float x)
+        {
+            var descriptor = this.catalog.Tools.Single(t => t.Name == "t_undo_move");
+            ToolInvoker.Invoke(descriptor, new JObject { ["name"] = "UndoGroupingTarget", ["x"] = x });
+        }
+
+        private float X => this.target.transform.localPosition.x;
+
+        [Test]
+        public void ThreeCallsTakeThreeUndoSteps()
+        {
+            this.Move(1f);
+            this.Move(2f);
+            this.Move(3f);
+            Assert.That(this.X, Is.EqualTo(3f));
+
+            Undo.PerformUndo();
+            Assert.That(this.X, Is.EqualTo(2f), "one undo reversed more than the last call");
+
+            Undo.PerformUndo();
+            Assert.That(this.X, Is.EqualTo(1f));
+
+            Undo.PerformUndo();
+            Assert.That(this.X, Is.EqualTo(0f), "the earliest call did not come back");
+        }
+
+        [Test]
+        public void RedoReappliesOneCallAtATime()
+        {
+            this.Move(1f);
+            this.Move(2f);
+
+            Undo.PerformUndo();
+            Assert.That(this.X, Is.EqualTo(1f));
+
+            Undo.PerformRedo();
+            Assert.That(this.X, Is.EqualTo(2f));
+        }
+
+        [Test]
+        public void EachCallGetsItsOwnGroupIndex()
+        {
+            this.Move(1f);
+            var first = Undo.GetCurrentGroup();
+
+            this.Move(2f);
+            var second = Undo.GetCurrentGroup();
+
+            Assert.That(second, Is.GreaterThan(first),
+                "consecutive calls shared a group, which is what made one undo reverse both");
+        }
+
+        [Test]
+        public void TheGroupIsNamedAfterTheTool()
+        {
+            this.Move(1f);
+
+            Assert.That(Undo.GetCurrentGroupName(), Is.EqualTo("Test Move"));
+        }
+
+        [Test]
+        public void AToolWithoutAnUndoGroupDoesNotTouchTheStack()
+        {
+            this.Move(1f);
+
+            var before = Undo.GetCurrentGroup();
+            var descriptor = this.catalog.Tools.Single(t => t.Name == "t_undo_none");
+            ToolInvoker.Invoke(descriptor, new JObject { ["name"] = "UndoGroupingTarget", ["x"] = 9f });
+
+            Assert.That(Undo.GetCurrentGroup(), Is.EqualTo(before));
+            Assert.That(this.X, Is.EqualTo(9f));
+
+            // The ungrouped write is not undoable, so undoing takes the value back past it to
+            // where the last grouped call left it.
+            Undo.PerformUndo();
+            Assert.That(this.X, Is.EqualTo(0f));
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/UndoGroupingTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/UndoGroupingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c57b02ec0eec73409d7ba3d62945bd8

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AssetTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AssetTools.cs
@@ -1,0 +1,304 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using UnityEditor;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Finding and rearranging project assets.
+    /// </summary>
+    /// <remarks>
+    /// Deletion goes to the trash rather than <c>AssetDatabase.DeleteAsset</c>. The alternative
+    /// was to declare the tool destructive and demand a confirmation on every call, which costs
+    /// a round trip every time and still loses the file when someone confirms the wrong one.
+    /// Recoverable beats gated.
+    /// </remarks>
+    internal static class AssetTools
+    {
+        [McpTool(
+            "asset_find",
+            "Search the project for assets. Combine a type filter with a folder to keep results " +
+            "small — an unfiltered search returns the entire project, which is rarely the question.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject Find(
+            [McpArg("type", "Unity type to filter by, e.g. Material, Texture2D, MonoScript, Prefab.")]
+            string type = null,
+            [McpArg("name", "Name fragment to match.")]
+            string name = null,
+            [McpArg("folder", "Restrict to this folder, e.g. Assets/Art.")]
+            string folder = null,
+            [McpArg("label", "Restrict to assets carrying this label.")]
+            string label = null,
+            [McpArg("limit", "Maximum results to return.")]
+            int limit = 50,
+            [McpArg("offset", "Results to skip, for paging.")]
+            int offset = 0)
+        {
+            var terms = new System.Collections.Generic.List<string>();
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                terms.Add(name);
+            }
+
+            if (!string.IsNullOrWhiteSpace(type))
+            {
+                terms.Add($"t:{type}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(label))
+            {
+                terms.Add($"l:{label}");
+            }
+
+            string[] guids;
+
+            if (string.IsNullOrWhiteSpace(folder))
+            {
+                guids = AssetDatabase.FindAssets(string.Join(" ", terms));
+            }
+            else
+            {
+                var normalised = folder.Replace('\\', '/').TrimEnd('/');
+
+                if (!AssetDatabase.IsValidFolder(normalised))
+                {
+                    throw new McpToolException(
+                        "not_found",
+                        $"'{folder}' is not a folder in this project. Folder paths start at 'Assets/'.");
+                }
+
+                guids = AssetDatabase.FindAssets(string.Join(" ", terms), new[] { normalised });
+            }
+
+            var total = guids.Length;
+            var page = guids.Skip(Math.Max(offset, 0)).Take(Math.Max(limit, 0)).ToArray();
+
+            var results = new JArray(page.Select(guid =>
+            {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+
+                return (object)new JObject
+                {
+                    ["path"] = path,
+                    ["guid"] = guid,
+                    ["type"] = AssetDatabase.GetMainAssetTypeAtPath(path)?.Name,
+                };
+            }).ToArray());
+
+            return new JObject
+            {
+                ["total"] = total,
+                ["assets"] = results,
+                ["truncated"] = offset + page.Length < total,
+            };
+        }
+
+        [McpTool(
+            "asset_info",
+            "Describe one asset: its type, GUID, importer, labels and what it depends on.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject Info(
+            [McpArg("path", "Project path of the asset, e.g. Assets/Art/Wood.mat.")]
+            string path = null,
+            [McpArg("include_dependencies", "List the assets this one references.")]
+            bool includeDependencies = false)
+        {
+            var asset = Require(path);
+            var importer = AssetImporter.GetAtPath(path);
+
+            var result = new JObject
+            {
+                ["path"] = path,
+                ["guid"] = AssetDatabase.AssetPathToGUID(path),
+                ["type"] = AssetDatabase.GetMainAssetTypeAtPath(path)?.FullName,
+                ["name"] = asset.name,
+                ["isFolder"] = AssetDatabase.IsValidFolder(path),
+                ["importer"] = importer == null ? null : (JToken)importer.GetType().Name,
+                ["labels"] = new JArray(AssetDatabase.GetLabels(asset).Cast<object>().ToArray()),
+            };
+
+            if (includeDependencies)
+            {
+                result["dependencies"] = new JArray(
+                    AssetDatabase.GetDependencies(path, false).Cast<object>().ToArray());
+            }
+
+            return result;
+        }
+
+        [McpTool(
+            "asset_create_folder",
+            "Create a folder, including any missing parents.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject CreateFolder(
+            [McpArg("path", "Folder to create, e.g. Assets/Art/Materials.")]
+            string path = null)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", "'path' is required.");
+            }
+
+            var normalised = path.Replace('\\', '/').TrimEnd('/');
+
+            if (!normalised.StartsWith("Assets", StringComparison.Ordinal))
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    $"'{path}' is outside the project. Asset paths start at 'Assets/'.");
+            }
+
+            if (AssetDatabase.IsValidFolder(normalised))
+            {
+                return new JObject { ["path"] = normalised, ["created"] = false };
+            }
+
+            var segments = normalised.Split('/');
+            var current = segments[0];
+
+            for (var i = 1; i < segments.Length; i++)
+            {
+                var next = $"{current}/{segments[i]}";
+
+                if (!AssetDatabase.IsValidFolder(next))
+                {
+                    var guid = AssetDatabase.CreateFolder(current, segments[i]);
+
+                    if (string.IsNullOrEmpty(guid))
+                    {
+                        throw new McpToolException("tool_failed", $"Unity refused to create '{next}'.");
+                    }
+                }
+
+                current = next;
+            }
+
+            return new JObject { ["path"] = normalised, ["created"] = true };
+        }
+
+        [McpTool(
+            "asset_move",
+            "Move or rename an asset, keeping its GUID so references survive.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject Move(
+            [McpArg("path", "Current project path of the asset.")]
+            string path = null,
+            [McpArg("destination", "New path, including the file name and extension.")]
+            string destination = null)
+        {
+            Require(path);
+
+            if (string.IsNullOrWhiteSpace(destination))
+            {
+                throw new McpToolException("invalid_params", "'destination' is required.");
+            }
+
+            var target = destination.Replace('\\', '/');
+            var parent = Path.GetDirectoryName(target)?.Replace('\\', '/');
+
+            if (!string.IsNullOrEmpty(parent) && !AssetDatabase.IsValidFolder(parent))
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"'{parent}' does not exist. Create it with asset_create_folder first.");
+            }
+
+            // Returns the reason as a string rather than throwing, and an empty string means it
+            // worked — easy to mistake for a failure if the result is not checked.
+            var error = AssetDatabase.MoveAsset(path, target);
+
+            if (!string.IsNullOrEmpty(error))
+            {
+                throw new McpToolException("tool_failed", error);
+            }
+
+            return new JObject
+            {
+                ["from"] = path,
+                ["path"] = target,
+                ["guid"] = AssetDatabase.AssetPathToGUID(target),
+            };
+        }
+
+        [McpTool(
+            "asset_delete",
+            "Move an asset to the OS trash. Recoverable from there, so this does not need confirming.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject Delete(
+            [McpArg("path", "Project path of the asset to remove.")]
+            string path = null)
+        {
+            Require(path);
+
+            if (!AssetDatabase.MoveAssetToTrash(path))
+            {
+                throw new McpToolException(
+                    "tool_failed",
+                    $"Unity would not move '{path}' to the trash. It may be open, locked, or outside Assets/.");
+            }
+
+            return new JObject { ["deleted"] = true, ["path"] = path, ["recoverable"] = "OS trash" };
+        }
+
+        [McpTool(
+            "asset_reimport",
+            "Reimport an asset or a whole folder. Needed after editing a file on disk outside the " +
+            "Editor, and after changing importer settings.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject Reimport(
+            [McpArg("path", "Asset or folder to reimport.")]
+            string path = null,
+            [McpArg("recursive", "For a folder, reimport everything inside it.")]
+            bool recursive = true)
+        {
+            Require(path);
+
+            var options = ImportAssetOptions.ForceUpdate;
+
+            if (recursive && AssetDatabase.IsValidFolder(path))
+            {
+                options |= ImportAssetOptions.ImportRecursive;
+            }
+
+            AssetDatabase.ImportAsset(path, options);
+
+            return new JObject
+            {
+                ["path"] = path,
+                ["reimported"] = true,
+                ["note"] = "Reimporting a script does not recompile it; use compile_request for that.",
+            };
+        }
+
+        private static UnityEngine.Object Require(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", "'path' is required.");
+            }
+
+            var normalised = path.Replace('\\', '/');
+            var asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(normalised);
+
+            if (asset == null)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"No asset at '{path}'. Paths are project-relative and start at 'Assets/' or " +
+                    "'Packages/'; asset_find will give you exact ones.");
+            }
+
+            return asset;
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AssetTools.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AssetTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a1910f38cc871ba4790e8b33bdb3f7e3

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/BuildTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/BuildTools.cs
@@ -1,0 +1,244 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using UnityEditor;
+using UnityEditor.Build.Reporting;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Player builds, and the settings they run from.
+    /// </summary>
+    /// <remarks>
+    /// Building belongs in the Editor rather than behind the Hub CLI: it needs the open project's
+    /// scenes, its build settings and its active target, none of which the Hub knows about.
+    /// Installing editors and modules is the opposite case and is left to the Hub — see the
+    /// message on <see cref="SwitchTarget"/> when a target is not installed.
+    /// <para>
+    /// A build takes minutes, so these calls cross the synchronous window and come back as a job
+    /// id. That is the intended path: poll it rather than calling again.
+    /// </para>
+    /// </remarks>
+    internal static class BuildTools
+    {
+        [McpTool(
+            "build_settings",
+            "Report the active build target, the scenes in the build, and whether the required " +
+            "module is installed. Read this before building — the scene list is the most common " +
+            "reason a build produces something unexpected.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject Settings()
+        {
+            var active = EditorUserBuildSettings.activeBuildTarget;
+
+            var scenes = new JArray(EditorBuildSettings.scenes.Select((s, i) => (object)new JObject
+            {
+                ["path"] = s.path,
+                ["enabled"] = s.enabled,
+                ["buildIndex"] = i,
+            }).ToArray());
+
+            return new JObject
+            {
+                ["activeBuildTarget"] = active.ToString(),
+                ["activeBuildTargetGroup"] = BuildPipeline.GetBuildTargetGroup(active).ToString(),
+                ["supported"] = BuildPipeline.IsBuildTargetSupported(BuildPipeline.GetBuildTargetGroup(active), active),
+                ["developmentBuild"] = EditorUserBuildSettings.development,
+                ["scriptDebugging"] = EditorUserBuildSettings.allowDebugging,
+                ["sceneCount"] = EditorBuildSettings.scenes.Length,
+                ["enabledSceneCount"] = EditorBuildSettings.scenes.Count(s => s.enabled),
+                ["scenes"] = scenes,
+                ["productName"] = PlayerSettings.productName,
+                ["companyName"] = PlayerSettings.companyName,
+                ["bundleVersion"] = PlayerSettings.bundleVersion,
+            };
+        }
+
+        [McpTool(
+            "build_player",
+            "Build a player. Takes minutes, so it returns a job id to poll rather than an answer. " +
+            "The scenes in the build settings are used unless a list is given.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject BuildPlayer(
+            [McpArg("output_path", "Where to write the build, including the executable's file name.")]
+            string outputPath = null,
+            [McpArg("platform", "Build target, e.g. StandaloneWindows64, Android, iOS, WebGL. Defaults to the active one.")]
+            string platform = null,
+            [McpArg("scenes", "Scene paths to include; omit to use the enabled scenes in the build settings.")]
+            string[] scenes = null,
+            [McpArg("development", "Make a development build.")]
+            bool development = false)
+        {
+            // No default output path. A build writes outside the project, and guessing where is
+            // how an agent fills someone's desktop or overwrites a shipped folder.
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    "'output_path' is required. Builds are written outside the project, so the " +
+                    "destination has to be stated rather than assumed.");
+            }
+
+            var buildTarget = ResolveTarget(platform);
+            var group = BuildPipeline.GetBuildTargetGroup(buildTarget);
+
+            if (!BuildPipeline.IsBuildTargetSupported(group, buildTarget))
+            {
+                throw new McpToolException(
+                    "unsupported_platform",
+                    $"The {buildTarget} module is not installed for this Editor. Install it with the " +
+                    "Hub CLI: \"Unity Hub.exe\" -- --headless install-modules --version <editor> " +
+                    "--module <module>.",
+                    501);
+            }
+
+            var sceneList = scenes != null && scenes.Length > 0
+                ? scenes
+                : EditorBuildSettings.scenes.Where(s => s.enabled).Select(s => s.path).ToArray();
+
+            if (sceneList.Length == 0)
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    "No scenes to build. Enable some in the build settings, or pass 'scenes'. " +
+                    "Building with none produces an empty player rather than an error.");
+            }
+
+            foreach (var scene in sceneList)
+            {
+                if (AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(scene) == null)
+                {
+                    throw new McpToolException("not_found", $"No scene at '{scene}'.");
+                }
+            }
+
+            var directory = Path.GetDirectoryName(outputPath);
+
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var options = new BuildPlayerOptions
+            {
+                scenes = sceneList,
+                locationPathName = outputPath,
+                target = buildTarget,
+                targetGroup = group,
+                options = development
+                    ? BuildOptions.Development | BuildOptions.AllowDebugging
+                    : BuildOptions.None,
+            };
+
+            var report = BuildPipeline.BuildPlayer(options);
+            var summary = report.summary;
+
+            var messages = new JArray(report.steps
+                .SelectMany(step => step.messages)
+                .Where(m => m.type == LogType.Error || m.type == LogType.Exception)
+                .Take(20)
+                .Select(m => (object)new JObject { ["type"] = m.type.ToString(), ["message"] = m.content })
+                .ToArray());
+
+            var result = new JObject
+            {
+                ["result"] = summary.result.ToString(),
+                ["succeeded"] = summary.result == BuildResult.Succeeded,
+                ["outputPath"] = summary.outputPath,
+                ["target"] = summary.platform.ToString(),
+                ["totalSizeBytes"] = summary.totalSize,
+                ["totalSeconds"] = Math.Round(summary.totalTime.TotalSeconds, 1),
+                ["errors"] = summary.totalErrors,
+                ["warnings"] = summary.totalWarnings,
+                ["sceneCount"] = sceneList.Length,
+                ["messages"] = messages,
+            };
+
+            if (summary.result != BuildResult.Succeeded)
+            {
+                // Reported as a value rather than thrown: a failed build is an outcome with a
+                // report worth reading, not a malformed request.
+                result["note"] = "The build did not succeed. console_read_logs has the full output.";
+            }
+
+            return result;
+        }
+
+        [McpTool(
+            "build_switch_target",
+            "Switch the active build target. Reimports assets for the new platform, so it takes a " +
+            "while and comes back as a job.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject SwitchTarget(
+            [McpArg("platform", "Build target to switch to, e.g. StandaloneWindows64, Android, iOS, WebGL.")]
+            string platform = null)
+        {
+            var buildTarget = ResolveTarget(platform);
+            var group = BuildPipeline.GetBuildTargetGroup(buildTarget);
+
+            if (EditorUserBuildSettings.activeBuildTarget == buildTarget)
+            {
+                return new JObject
+                {
+                    ["switched"] = false,
+                    ["activeBuildTarget"] = buildTarget.ToString(),
+                    ["note"] = "Already the active target.",
+                };
+            }
+
+            if (!BuildPipeline.IsBuildTargetSupported(group, buildTarget))
+            {
+                throw new McpToolException(
+                    "unsupported_platform",
+                    $"The {buildTarget} module is not installed for this Editor. Install it with the " +
+                    "Hub CLI: \"Unity Hub.exe\" -- --headless install-modules --version <editor> " +
+                    "--module <module>.",
+                    501);
+            }
+
+            if (!EditorUserBuildSettings.SwitchActiveBuildTarget(group, buildTarget))
+            {
+                throw new McpToolException("tool_failed", $"Unity would not switch to {buildTarget}.");
+            }
+
+            return new JObject
+            {
+                ["switched"] = true,
+                ["activeBuildTarget"] = EditorUserBuildSettings.activeBuildTarget.ToString(),
+            };
+        }
+
+        // Named "platform" on the wire: "target" is reserved by the invoker for choosing which
+        // Editor a call goes to, and the catalog refuses a tool that shadows it.
+        private static BuildTarget ResolveTarget(string platform)
+        {
+            if (string.IsNullOrWhiteSpace(platform))
+            {
+                return EditorUserBuildSettings.activeBuildTarget;
+            }
+
+            if (Enum.TryParse<BuildTarget>(platform, true, out var parsed) && parsed != BuildTarget.NoTarget)
+            {
+                return parsed;
+            }
+
+            var known = string.Join(", ", new[]
+            {
+                BuildTarget.StandaloneWindows64, BuildTarget.StandaloneOSX, BuildTarget.StandaloneLinux64,
+                BuildTarget.Android, BuildTarget.iOS, BuildTarget.WebGL,
+            }.Select(t => t.ToString()));
+
+            throw new McpToolException(
+                "invalid_params",
+                $"'{platform}' is not a build target. Common ones: {known}.");
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/BuildTools.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/BuildTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9a7caf7b90be7464ba14b68b31ae810f

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorNotes.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorNotes.cs
@@ -1,0 +1,36 @@
+using Newtonsoft.Json.Linq;
+
+using UnityEditor;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Warnings that belong on a result rather than in a description.
+    /// </summary>
+    internal static class EditorNotes
+    {
+        /// <summary>
+        /// Adds a note when a scene change is about to be thrown away.
+        /// </summary>
+        /// <remarks>
+        /// Play Mode reverts the scene on exit. A tool that edits a GameObject during Play Mode
+        /// therefore succeeds, reports the new state truthfully, and leaves nothing behind — the
+        /// caller has no way to tell that from a durable edit, and finds out when the object is
+        /// gone. Measured: gameobject_create in Play Mode returns a full success payload and the
+        /// object does not exist after stopping, while asset edits made at the same moment
+        /// survive. The asymmetry is the dangerous part, so it is said out loud at the moment it
+        /// applies rather than left in a description that is read once.
+        /// </remarks>
+        public static JObject SceneChange(JObject result)
+        {
+            if (result != null && EditorApplication.isPlaying)
+            {
+                result["playModeWarning"] =
+                    "Play Mode is running. Scene changes are reverted when it stops, so this edit " +
+                    "will not survive. Asset changes made now do survive.";
+            }
+
+            return result;
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorNotes.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorNotes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa39500538a5bd746ac9daa306fc9635

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorTools.cs
@@ -30,13 +30,17 @@ namespace UnityMCP.Editor.Tools
             [McpArg("width", "Exact capture width; overrides max_size.")]
             int? width = null,
             [McpArg("height", "Exact capture height; overrides max_size.")]
-            int? height = null)
+            int? height = null,
+            [McpArg("save_path", "Write the PNG here and return the path instead of the image. " +
+                                 "Use this when the picture is going to render_compare rather than to a human.")]
+            string savePath = null)
         {
             return ScreenshotCapture.Capture(ToolArgs.Of(
                 ("view", view),
                 ("maxSize", maxSize),
                 ("width", width),
-                ("height", height)));
+                ("height", height),
+                ("savePath", savePath)));
         }
 
         [McpTool(

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
@@ -103,12 +103,12 @@ namespace UnityMCP.Editor.Tools
             // work.
             Undo.DestroyObjectImmediate(go);
 
-            return new JObject
+            return EditorNotes.SceneChange(new JObject
             {
                 ["deleted"] = true,
                 ["name"] = name,
                 ["path"] = path,
-            };
+            });
         }
 
         [McpTool(
@@ -428,7 +428,7 @@ namespace UnityMCP.Editor.Tools
         {
             var t = go.transform;
 
-            return new JObject
+            return EditorNotes.SceneChange(new JObject
             {
                 ["name"] = go.name,
                 ["path"] = ObjectResolve.PathOf(go),
@@ -444,7 +444,7 @@ namespace UnityMCP.Editor.Tools
                     .Select(c => (object)c.GetType().Name)
                     .ToArray()),
                 ["childCount"] = t.childCount,
-            };
+            });
         }
 
         private static JObject Vector(Vector3 v)

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
@@ -1,0 +1,455 @@
+using System;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using UnityEditor;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Creating, moving and removing GameObjects.
+    /// </summary>
+    /// <remarks>
+    /// Every mutation here goes through <c>Undo</c> and declares an <c>UndoGroup</c>, so one
+    /// call is one Ctrl+Z. That is the difference between letting an agent edit a scene and
+    /// letting an agent edit a scene you can back out of, and it is why these exist as tools
+    /// rather than as advice to write the equivalent through execute_code — arbitrary C# is not
+    /// on the undo stack and cannot be taken back.
+    /// </remarks>
+    internal static class GameObjectTools
+    {
+        [McpTool(
+            "gameobject_create",
+            "Create a GameObject, optionally as a primitive and optionally parented to an existing " +
+            "object. Returns the path to address it by later.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Create GameObject")]
+        public static JObject Create(
+            [McpArg("name", "Name for the new object. Defaults to the primitive's name, or 'GameObject'.")]
+            string name = null,
+            [McpArg("primitive", "Cube, Sphere, Capsule, Cylinder, Plane or Quad. Omit for an empty object.")]
+            string primitive = null,
+            [McpArg("parent_path", "Hierarchy path of the parent; omit to create at the scene root.")]
+            string parentPath = null,
+            [McpArg("parent_instance_id", "Parent by instance id.")]
+            int? parentInstanceId = null,
+            [McpArg("position", "Local position, as {x, y, z}.")]
+            JObject position = null,
+            [McpArg("rotation", "Local euler angles, as {x, y, z}.")]
+            JObject rotation = null,
+            [McpArg("scale", "Local scale, as {x, y, z}.")]
+            JObject scale = null)
+        {
+            GameObject go;
+
+            if (string.IsNullOrWhiteSpace(primitive))
+            {
+                go = new GameObject(string.IsNullOrWhiteSpace(name) ? "GameObject" : name);
+            }
+            else
+            {
+                if (!Enum.TryParse<PrimitiveType>(primitive, true, out var type))
+                {
+                    throw new McpToolException(
+                        "invalid_params",
+                        $"'{primitive}' is not a primitive. Use one of: {string.Join(", ", Enum.GetNames(typeof(PrimitiveType)))}.");
+                }
+
+                go = GameObject.CreatePrimitive(type);
+
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    go.name = name;
+                }
+            }
+
+            Undo.RegisterCreatedObjectUndo(go, "MCP Create GameObject");
+
+            if (!string.IsNullOrWhiteSpace(parentPath) || parentInstanceId.HasValue)
+            {
+                var parent = ObjectResolve.Object(parentPath, parentInstanceId, "parent_path");
+                Undo.SetTransformParent(go.transform, parent.transform, "MCP Create GameObject");
+            }
+
+            ApplyTransform(go.transform, position, rotation, scale);
+            Selection.activeGameObject = go;
+
+            return Describe(go);
+        }
+
+        [McpTool(
+            "gameobject_delete",
+            "Delete a GameObject and its children. Undoable, so this does not need confirming.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Delete GameObject")]
+        public static JObject Delete(
+            [McpArg("object_path", "Hierarchy path, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null)
+        {
+            var go = ObjectResolve.Object(objectPath, instanceId);
+            var path = ObjectResolve.PathOf(go);
+            var name = go.name;
+
+            // DestroyImmediate would put it beyond recovery. This is the one call that makes
+            // the difference between an agent's mistake being an inconvenience and being lost
+            // work.
+            Undo.DestroyObjectImmediate(go);
+
+            return new JObject
+            {
+                ["deleted"] = true,
+                ["name"] = name,
+                ["path"] = path,
+            };
+        }
+
+        [McpTool(
+            "gameobject_reparent",
+            "Move a GameObject under a different parent, or to the scene root. World position is " +
+            "preserved by default.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Reparent GameObject")]
+        public static JObject Reparent(
+            [McpArg("object_path", "Hierarchy path, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null,
+            [McpArg("parent_path", "Path of the new parent. Omit to move it to the scene root.")]
+            string parentPath = null,
+            [McpArg("parent_instance_id", "New parent by instance id.")]
+            int? parentInstanceId = null,
+            [McpArg("sibling_index", "Position among the new parent's children; omit to append.")]
+            int? siblingIndex = null,
+            [McpArg("keep_world_position", "Keep the object where it is in world space.")]
+            bool keepWorldPosition = true)
+        {
+            var go = ObjectResolve.Object(objectPath, instanceId);
+
+            Transform parent = null;
+
+            if (!string.IsNullOrWhiteSpace(parentPath) || parentInstanceId.HasValue)
+            {
+                var parentGo = ObjectResolve.Object(parentPath, parentInstanceId, "parent_path");
+
+                if (parentGo.transform.IsChildOf(go.transform))
+                {
+                    throw new McpToolException(
+                        "invalid_params",
+                        $"'{ObjectResolve.PathOf(parentGo)}' is inside '{ObjectResolve.PathOf(go)}'; " +
+                        "an object cannot be parented to its own descendant.");
+                }
+
+                parent = parentGo.transform;
+            }
+
+            Undo.SetTransformParent(go.transform, parent, "MCP Reparent GameObject");
+
+            if (!keepWorldPosition)
+            {
+                Undo.RecordObject(go.transform, "MCP Reparent GameObject");
+                go.transform.localPosition = Vector3.zero;
+                go.transform.localRotation = Quaternion.identity;
+            }
+
+            if (siblingIndex.HasValue)
+            {
+                go.transform.SetSiblingIndex(siblingIndex.Value);
+            }
+
+            return Describe(go);
+        }
+
+        [McpTool(
+            "gameobject_duplicate",
+            "Duplicate a GameObject, keeping its parent and any prefab link.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Duplicate GameObject")]
+        public static JObject Duplicate(
+            [McpArg("object_path", "Hierarchy path, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null,
+            [McpArg("name", "Name for the copy. Defaults to Unity's own numbering.")]
+            string name = null)
+        {
+            var source = ObjectResolve.Object(objectPath, instanceId);
+            var copy = UnityEngine.Object.Instantiate(source, source.transform.parent);
+
+            copy.name = string.IsNullOrWhiteSpace(name)
+                ? GameObjectUtility.GetUniqueNameForSibling(source.transform.parent, source.name)
+                : name;
+
+            Undo.RegisterCreatedObjectUndo(copy, "MCP Duplicate GameObject");
+            Selection.activeGameObject = copy;
+
+            return Describe(copy);
+        }
+
+        [McpTool(
+            "gameobject_set_transform",
+            "Set position, rotation or scale. Only the parts given are changed, so this can nudge " +
+            "one axis without restating the rest.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Set Transform")]
+        public static JObject SetTransform(
+            [McpArg("object_path", "Hierarchy path, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null,
+            [McpArg("position", "Position, as {x, y, z}. Any missing axis is left alone.")]
+            JObject position = null,
+            [McpArg("rotation", "Euler angles, as {x, y, z}.")]
+            JObject rotation = null,
+            [McpArg("scale", "Scale, as {x, y, z}.")]
+            JObject scale = null,
+            [McpArg("world", "Treat position and rotation as world space rather than local.")]
+            bool world = false)
+        {
+            var go = ObjectResolve.Object(objectPath, instanceId);
+
+            Undo.RecordObject(go.transform, "MCP Set Transform");
+            ApplyTransform(go.transform, position, rotation, scale, world);
+
+            return Describe(go);
+        }
+
+        [McpTool(
+            "gameobject_set_active",
+            "Activate or deactivate a GameObject.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Set Active")]
+        public static JObject SetActive(
+            [McpArg("object_path", "Hierarchy path, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null,
+            [McpArg("active", "Whether the object should be active.")]
+            bool active = true)
+        {
+            var go = ObjectResolve.Object(objectPath, instanceId);
+
+            Undo.RecordObject(go, "MCP Set Active");
+            go.SetActive(active);
+
+            return Describe(go);
+        }
+
+        [McpTool(
+            "gameobject_add_component",
+            "Add a component by type name. Unqualified names are resolved against the loaded " +
+            "assemblies, so 'Rigidbody' and 'UnityEngine.Rigidbody' both work.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Add Component")]
+        public static JObject AddComponent(
+            [McpArg("object_path", "Hierarchy path, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null,
+            [McpArg("component_type", "Type name of the component to add.")]
+            string componentType = null)
+        {
+            var go = ObjectResolve.Object(objectPath, instanceId);
+            var type = FindComponentType(componentType);
+
+            var added = Undo.AddComponent(go, type);
+
+            if (added == null)
+            {
+                throw new McpToolException(
+                    "tool_failed",
+                    $"Unity refused to add {type.Name} to '{go.name}'. A RequireComponent dependency " +
+                    "may be missing, or the component may already be present and disallow duplicates.");
+            }
+
+            return Describe(go);
+        }
+
+        [McpTool(
+            "gameobject_remove_component",
+            "Remove a component by type name.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Remove Component")]
+        public static JObject RemoveComponent(
+            [McpArg("object_path", "Hierarchy path, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null,
+            [McpArg("component_type", "Type name of the component to remove.")]
+            string componentType = null,
+            [McpArg("index", "Which one, when the object carries several of the same type.")]
+            int index = 0)
+        {
+            var go = ObjectResolve.Object(objectPath, instanceId);
+            var component = ObjectResolve.Component(go, componentType, index);
+
+            if (component is Transform)
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    "Transform cannot be removed from a GameObject.");
+            }
+
+            Undo.DestroyObjectImmediate(component);
+
+            return Describe(go);
+        }
+
+        private static Type FindComponentType(string typeName)
+        {
+            if (string.IsNullOrWhiteSpace(typeName))
+            {
+                throw new McpToolException("invalid_params", "'component_type' is required.");
+            }
+
+            var exact = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(SafeTypes)
+                .Where(t => typeof(Component).IsAssignableFrom(t) && !t.IsAbstract)
+                .Where(t => t.FullName == typeName || t.Name == typeName)
+                .OrderBy(t => t.FullName == typeName ? 0 : 1)
+                .ToArray();
+
+            if (exact.Length == 0)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"No component type named '{typeName}' is loaded. Use the full name if it is " +
+                    "ambiguous, and check the script compiled with compile_status.");
+            }
+
+            // Several assemblies can define the same short name. Reporting that is more useful
+            // than picking one and leaving the caller to wonder which they got.
+            if (exact.Length > 1 && exact[0].FullName != typeName)
+            {
+                var candidates = string.Join(", ", exact.Take(6).Select(t => t.FullName));
+
+                throw new McpToolException(
+                    "invalid_params",
+                    $"'{typeName}' is ambiguous: {candidates}. Pass the full name.");
+            }
+
+            return exact[0];
+        }
+
+        private static Type[] SafeTypes(System.Reflection.Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (System.Reflection.ReflectionTypeLoadException e)
+            {
+                return e.Types.Where(t => t != null).ToArray();
+            }
+            catch
+            {
+                return Array.Empty<Type>();
+            }
+        }
+
+        private static void ApplyTransform(
+            Transform transform,
+            JObject position,
+            JObject rotation,
+            JObject scale,
+            bool world = false)
+        {
+            if (position != null)
+            {
+                var current = world ? transform.position : transform.localPosition;
+                var next = ReadVector(position, current, "position");
+
+                if (world)
+                {
+                    transform.position = next;
+                }
+                else
+                {
+                    transform.localPosition = next;
+                }
+            }
+
+            if (rotation != null)
+            {
+                var current = world ? transform.eulerAngles : transform.localEulerAngles;
+                var next = ReadVector(rotation, current, "rotation");
+
+                if (world)
+                {
+                    transform.eulerAngles = next;
+                }
+                else
+                {
+                    transform.localEulerAngles = next;
+                }
+            }
+
+            if (scale != null)
+            {
+                transform.localScale = ReadVector(scale, transform.localScale, "scale");
+            }
+        }
+
+        /// <summary>
+        /// Reads {x, y, z}, leaving out axes alone rather than zeroing them.
+        /// </summary>
+        private static Vector3 ReadVector(JObject source, Vector3 fallback, string argumentName)
+        {
+            float Axis(string key, float current)
+            {
+                var token = source[key];
+
+                if (token == null || token.Type == JTokenType.Null)
+                {
+                    return current;
+                }
+
+                if (token.Type != JTokenType.Float && token.Type != JTokenType.Integer)
+                {
+                    throw new McpToolException(
+                        "invalid_params",
+                        $"'{argumentName}.{key}' must be a number, not {token.Type}.");
+                }
+
+                return token.Value<float>();
+            }
+
+            return new Vector3(Axis("x", fallback.x), Axis("y", fallback.y), Axis("z", fallback.z));
+        }
+
+        private static JObject Describe(GameObject go)
+        {
+            var t = go.transform;
+
+            return new JObject
+            {
+                ["name"] = go.name,
+                ["path"] = ObjectResolve.PathOf(go),
+                ["instanceId"] = go.GetInstanceID(),
+                ["active"] = go.activeSelf,
+                ["activeInHierarchy"] = go.activeInHierarchy,
+                ["parent"] = t.parent == null ? null : (JToken)ObjectResolve.PathOf(t.parent.gameObject),
+                ["localPosition"] = Vector(t.localPosition),
+                ["localEulerAngles"] = Vector(t.localEulerAngles),
+                ["localScale"] = Vector(t.localScale),
+                ["components"] = new JArray(go.GetComponents<Component>()
+                    .Where(c => c != null)
+                    .Select(c => (object)c.GetType().Name)
+                    .ToArray()),
+                ["childCount"] = t.childCount,
+            };
+        }
+
+        private static JObject Vector(Vector3 v)
+        {
+            return new JObject { ["x"] = v.x, ["y"] = v.y, ["z"] = v.z };
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
@@ -80,7 +80,7 @@ namespace UnityMCP.Editor.Tools
             ApplyTransform(go.transform, position, rotation, scale);
             Selection.activeGameObject = go;
 
-            return Describe(go);
+            return Describe(go, transform: true);
         }
 
         [McpTool(
@@ -164,7 +164,7 @@ namespace UnityMCP.Editor.Tools
                 go.transform.SetSiblingIndex(siblingIndex.Value);
             }
 
-            return Describe(go);
+            return Describe(go, transform: true);
         }
 
         [McpTool(
@@ -218,7 +218,7 @@ namespace UnityMCP.Editor.Tools
             Undo.RecordObject(go.transform, "MCP Set Transform");
             ApplyTransform(go.transform, position, rotation, scale, world);
 
-            return Describe(go);
+            return Describe(go, transform: true);
         }
 
         [McpTool(
@@ -269,7 +269,7 @@ namespace UnityMCP.Editor.Tools
                     "may be missing, or the component may already be present and disallow duplicates.");
             }
 
-            return Describe(go);
+            return Describe(go, components: true);
         }
 
         [McpTool(
@@ -299,7 +299,7 @@ namespace UnityMCP.Editor.Tools
 
             Undo.DestroyObjectImmediate(component);
 
-            return Describe(go);
+            return Describe(go, components: true);
         }
 
         private static Type FindComponentType(string typeName)
@@ -424,27 +424,47 @@ namespace UnityMCP.Editor.Tools
             return new Vector3(Axis("x", fallback.x), Axis("y", fallback.y), Axis("z", fallback.z));
         }
 
-        private static JObject Describe(GameObject go)
+        /// <summary>
+        /// Describes the object a call acted on.
+        /// </summary>
+        /// <remarks>
+        /// Only what the operation was about. This used to return the name, path, instance id,
+        /// both active flags, the parent, all three transform vectors, every component name and
+        /// the child count, on every call — including gameobject_set_active, where the only
+        /// thing a caller wants to know is that it worked. That is a few hundred characters per
+        /// call of mostly unasked-for detail, and unlike the tool catalogue it is paid again
+        /// every time. The transform and the component list are added by the tools that change
+        /// them; scene_browse_hierarchy and inspect_read answer the rest when it is the actual
+        /// question.
+        /// </remarks>
+        private static JObject Describe(GameObject go, bool transform = false, bool components = false)
         {
             var t = go.transform;
 
-            return EditorNotes.SceneChange(new JObject
+            var result = new JObject
             {
                 ["name"] = go.name,
                 ["path"] = ObjectResolve.PathOf(go),
                 ["instanceId"] = go.GetInstanceID(),
                 ["active"] = go.activeSelf,
-                ["activeInHierarchy"] = go.activeInHierarchy,
-                ["parent"] = t.parent == null ? null : (JToken)ObjectResolve.PathOf(t.parent.gameObject),
-                ["localPosition"] = Vector(t.localPosition),
-                ["localEulerAngles"] = Vector(t.localEulerAngles),
-                ["localScale"] = Vector(t.localScale),
-                ["components"] = new JArray(go.GetComponents<Component>()
+            };
+
+            if (transform)
+            {
+                result["localPosition"] = Vector(t.localPosition);
+                result["localEulerAngles"] = Vector(t.localEulerAngles);
+                result["localScale"] = Vector(t.localScale);
+            }
+
+            if (components)
+            {
+                result["components"] = new JArray(go.GetComponents<Component>()
                     .Where(c => c != null)
                     .Select(c => (object)c.GetType().Name)
-                    .ToArray()),
-                ["childCount"] = t.childCount,
-            });
+                    .ToArray());
+            }
+
+            return EditorNotes.SceneChange(result);
         }
 
         private static JObject Vector(Vector3 v)

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8193455d241a7e24b89f9629b399d3ef

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GpuTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GpuTools.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.Rendering;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Reading GPU memory back and describing it.
+    /// </summary>
+    /// <remarks>
+    /// Reports statistics rather than contents. A shadow page pool or a cull counter buffer is
+    /// megabytes; what a question about it actually needs is "is anything in there", "what is the
+    /// range", "how many are still zero" — and those answers are a few dozen bytes. Raw elements
+    /// are available, but only as many as are asked for.
+    /// </remarks>
+    internal static class GpuTools
+    {
+        [McpTool(
+            "gpu_readback",
+            "Read a GPU buffer or texture back and report its statistics: range, mean, how many " +
+            "elements are zero, and a histogram. Point it at a buffer with the same path syntax as " +
+            "reflect_read. Use this to answer whether a compute pass actually wrote anything, which " +
+            "is the question a screenshot cannot settle.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject Readback(
+            [McpArg("path", "Path to a GraphicsBuffer, ComputeBuffer or Texture, as reflect_read takes.")]
+            string path = null,
+            [McpArg("global_texture", "Read a globally bound shader texture by name instead.")]
+            string globalTexture = null,
+            [McpArg("format", "How to read each element: uint, int or float.")]
+            string format = "float",
+            [McpArg("offset", "First element to include.")]
+            int offset = 0,
+            [McpArg("count", "How many elements to examine; 0 reads everything.")]
+            int count = 0,
+            [McpArg("samples", "How many raw values to return alongside the statistics.")]
+            int samples = 8,
+            [McpArg("histogram", "Number of histogram buckets; 0 for none.")]
+            int histogram = 8)
+        {
+            var source = ResolveSource(path, globalTexture, out var description);
+            var kind = ParseFormat(format);
+
+            double[] values;
+            var meta = new JObject { ["source"] = description };
+
+            switch (source)
+            {
+                case GraphicsBuffer graphicsBuffer:
+                    meta["kind"] = "GraphicsBuffer";
+                    meta["elementCount"] = graphicsBuffer.count;
+                    meta["stride"] = graphicsBuffer.stride;
+                    values = ReadBuffer(request => AsyncGPUReadback.Request(graphicsBuffer), kind);
+                    break;
+
+                case ComputeBuffer computeBuffer:
+                    meta["kind"] = "ComputeBuffer";
+                    meta["elementCount"] = computeBuffer.count;
+                    meta["stride"] = computeBuffer.stride;
+                    values = ReadBuffer(request => AsyncGPUReadback.Request(computeBuffer), kind);
+                    break;
+
+                case Texture texture:
+                    meta["kind"] = texture.GetType().Name;
+                    meta["width"] = texture.width;
+                    meta["height"] = texture.height;
+                    values = ReadTexture(texture, kind, meta);
+                    break;
+
+                default:
+                    throw new McpToolException(
+                        "invalid_params",
+                        $"{description} is a {source.GetType().Name}, which is not a buffer or a texture.");
+            }
+
+            return Describe(values, offset, count, samples, histogram, meta);
+        }
+
+        private enum ElementKind
+        {
+            UInt,
+            Int,
+            Float,
+        }
+
+        private static ElementKind ParseFormat(string format)
+        {
+            switch ((format ?? "float").Trim().ToLowerInvariant())
+            {
+                case "uint":
+                case "u32":
+                    return ElementKind.UInt;
+
+                case "int":
+                case "i32":
+                    return ElementKind.Int;
+
+                case "float":
+                case "f32":
+                    return ElementKind.Float;
+
+                default:
+                    throw new McpToolException(
+                        "invalid_params",
+                        $"'{format}' is not an element format. Use uint, int or float.");
+            }
+        }
+
+        private static object ResolveSource(string path, string globalTexture, out string description)
+        {
+            if (!string.IsNullOrWhiteSpace(globalTexture))
+            {
+                var texture = Shader.GetGlobalTexture(globalTexture);
+
+                if (texture == null)
+                {
+                    throw new McpToolException(
+                        "not_found",
+                        $"No global texture named '{globalTexture}' is bound. Global bindings are set " +
+                        "per frame, so one that is only bound during a pass will not be here.");
+                }
+
+                description = $"global texture '{globalTexture}'";
+                return texture;
+            }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", "Either 'path' or 'global_texture' is required.");
+            }
+
+            var value = ReflectTools.ResolvePath(path, out _, out var walked);
+
+            if (value == null)
+            {
+                throw new McpToolException("not_found", $"'{walked}' is null.");
+            }
+
+            description = walked;
+            return value;
+        }
+
+        private static double[] ReadBuffer(Func<int, AsyncGPUReadbackRequest> requestFactory, ElementKind kind)
+        {
+            var request = requestFactory(0);
+            request.WaitForCompletion();
+
+            if (request.hasError)
+            {
+                throw new McpToolException(
+                    "tool_failed",
+                    "The readback failed. A buffer created without a readable target, or one already " +
+                    "released, cannot be read back.");
+            }
+
+            switch (kind)
+            {
+                case ElementKind.UInt:
+                    return request.GetData<uint>().Select(v => (double)v).ToArray();
+
+                case ElementKind.Int:
+                    return request.GetData<int>().Select(v => (double)v).ToArray();
+
+                default:
+                    return request.GetData<float>().Select(v => (double)v).ToArray();
+            }
+        }
+
+        private static double[] ReadTexture(Texture texture, ElementKind kind, JObject meta)
+        {
+            var graphicsFormat = kind == ElementKind.UInt
+                ? GraphicsFormat.R32_UInt
+                : kind == ElementKind.Int
+                    ? GraphicsFormat.R32_SInt
+                    : GraphicsFormat.R32_SFloat;
+
+            var request = AsyncGPUReadback.Request(texture, 0, graphicsFormat);
+            request.WaitForCompletion();
+
+            // Unity logs "R32_UInt ReadPixels failed" for integer formats and returns the data
+            // anyway. hasError is the thing to check; the console line is noise.
+            if (request.hasError)
+            {
+                throw new McpToolException(
+                    "tool_failed",
+                    $"The readback failed. {texture.name} may not be readable in {graphicsFormat}; " +
+                    "try a different format, and note that a RenderTexture must have been rendered to.");
+            }
+
+            meta["readAs"] = graphicsFormat.ToString();
+
+            switch (kind)
+            {
+                case ElementKind.UInt:
+                    return request.GetData<uint>().Select(v => (double)v).ToArray();
+
+                case ElementKind.Int:
+                    return request.GetData<int>().Select(v => (double)v).ToArray();
+
+                default:
+                    return request.GetData<float>().Select(v => (double)v).ToArray();
+            }
+        }
+
+        private static JObject Describe(
+            double[] values, int offset, int count, int samples, int buckets, JObject meta)
+        {
+            var start = Math.Max(offset, 0);
+            var length = count <= 0 ? values.Length - start : Math.Min(count, values.Length - start);
+
+            if (start >= values.Length || length <= 0)
+            {
+                meta["examined"] = 0;
+                meta["note"] = $"The window starts past the end; {values.Length} element(s) were read.";
+                return meta;
+            }
+
+            var min = double.MaxValue;
+            var max = double.MinValue;
+            var sum = 0d;
+            var zero = 0;
+
+            for (var i = start; i < start + length; i++)
+            {
+                var v = values[i];
+                if (v < min) min = v;
+                if (v > max) max = v;
+                sum += v;
+                if (v == 0d) zero++;
+            }
+
+            meta["readElements"] = values.Length;
+            meta["examined"] = length;
+            meta["min"] = min;
+            meta["max"] = max;
+            meta["mean"] = Math.Round(sum / length, 6);
+            meta["zeroCount"] = zero;
+            meta["nonZeroCount"] = length - zero;
+            // The question behind most readbacks is whether the pass ran at all.
+            meta["allZero"] = zero == length;
+
+            if (samples > 0)
+            {
+                meta["samples"] = new JArray(values.Skip(start).Take(Math.Min(samples, length))
+                    .Select(v => (object)v).ToArray());
+            }
+
+            if (buckets > 0 && max > min)
+            {
+                var counts = new int[buckets];
+
+                for (var i = start; i < start + length; i++)
+                {
+                    var bucket = (int)((values[i] - min) / (max - min) * buckets);
+                    counts[Math.Min(bucket, buckets - 1)]++;
+                }
+
+                meta["histogram"] = new JObject
+                {
+                    ["min"] = min,
+                    ["max"] = max,
+                    ["counts"] = new JArray(counts.Cast<object>().ToArray()),
+                };
+            }
+
+            return meta;
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GpuTools.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GpuTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86f422997f6949c4e88ef5e8345ae425

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ObjectResolve.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ObjectResolve.cs
@@ -1,0 +1,286 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using UnityEditor;
+using UnityEditor.SceneManagement;
+
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+using UnityMCP.Editor.Core;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Turns a hierarchy path or an instance id into the object it names, and back again.
+    /// </summary>
+    /// <remarks>
+    /// Shared rather than duplicated per tool, because "which object did you mean" is the one
+    /// question every authoring tool has to answer identically. Two things it fixes:
+    /// <para>
+    /// <c>GameObject.Find</c> only sees active objects, so the obvious implementation cannot
+    /// reach anything a caller has just deactivated — or anything that was inactive when they
+    /// looked at it. This walks the scene roots instead.
+    /// </para>
+    /// <para>
+    /// Sibling names repeat constantly in real scenes. Refusing on ambiguity would make the
+    /// tools unusable, and silently taking the first match makes them unpredictable, so a path
+    /// carries an index only where one is needed: <c>/Canvas/Button[1]/Text</c>. Paths written
+    /// by hand without indices still resolve, to the first match.
+    /// </para>
+    /// </remarks>
+    internal static class ObjectResolve
+    {
+        /// <summary>
+        /// Resolves a GameObject from a path, an instance id, or both.
+        /// </summary>
+        public static GameObject Object(string path, int? instanceId, string argumentName = "object_path")
+        {
+            if (instanceId.HasValue)
+            {
+                var byId = EditorUtility.InstanceIDToObject(instanceId.Value) as GameObject;
+
+                if (byId != null)
+                {
+                    return byId;
+                }
+
+                throw new McpToolException(
+                    "not_found",
+                    $"No GameObject has instance id {instanceId.Value}. Instance ids do not survive a " +
+                    "domain reload or a scene change; re-read the hierarchy to get current ones.");
+            }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    $"Either '{argumentName}' or 'instance_id' is required.");
+            }
+
+            var segments = path.Split('/').Where(s => s.Length > 0).ToArray();
+
+            if (segments.Length == 0)
+            {
+                throw new McpToolException("invalid_params", $"'{path}' does not name anything.");
+            }
+
+            IEnumerable<GameObject> level = SceneRoots();
+            GameObject current = null;
+
+            for (var depth = 0; depth < segments.Length; depth++)
+            {
+                var match = MatchSegment(level, segments[depth]);
+
+                if (match == null)
+                {
+                    throw new McpToolException("not_found", NotFoundMessage(path, segments, depth, level));
+                }
+
+                current = match;
+                level = Children(current);
+            }
+
+            return current;
+        }
+
+        /// <summary>
+        /// The path that <see cref="Object"/> will resolve back to this object.
+        /// </summary>
+        /// <remarks>
+        /// An index is appended only where the name alone is ambiguous among its siblings, so
+        /// the common case stays readable and the ambiguous case stays exact.
+        /// </remarks>
+        public static string PathOf(GameObject go)
+        {
+            if (go == null)
+            {
+                return null;
+            }
+
+            var parts = new List<string>();
+
+            for (var t = go.transform; t != null; t = t.parent)
+            {
+                parts.Add(Segment(t));
+            }
+
+            parts.Reverse();
+
+            var builder = new StringBuilder();
+
+            foreach (var part in parts)
+            {
+                builder.Append('/').Append(part);
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>Finds a component on an object, by type name.</summary>
+        public static Component Component(GameObject go, string typeName, int index = 0)
+        {
+            if (string.IsNullOrWhiteSpace(typeName))
+            {
+                throw new McpToolException("invalid_params", "'component_type' is required.");
+            }
+
+            var matches = go.GetComponents<Component>()
+                .Where(c => c != null && TypeMatches(c.GetType(), typeName))
+                .ToArray();
+
+            if (matches.Length == 0)
+            {
+                var present = string.Join(", ", go.GetComponents<Component>()
+                    .Where(c => c != null)
+                    .Select(c => c.GetType().Name));
+
+                throw new McpToolException(
+                    "not_found",
+                    $"'{go.name}' has no component matching '{typeName}'. It has: {present}.");
+            }
+
+            if (index < 0 || index >= matches.Length)
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    $"'{go.name}' has {matches.Length} component(s) matching '{typeName}'; index {index} is out of range.");
+            }
+
+            return matches[index];
+        }
+
+        /// <summary>Roots of every loaded scene, including prefab stages.</summary>
+        public static IEnumerable<GameObject> SceneRoots()
+        {
+            var stage = PrefabStageUtility.GetCurrentPrefabStage();
+
+            if (stage != null)
+            {
+                // While a prefab is open for editing its contents are not in any loaded scene's
+                // root list, and acting on the scene behind it is never what was meant.
+                yield return stage.prefabContentsRoot;
+
+                yield break;
+            }
+
+            for (var i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+
+                if (!scene.isLoaded)
+                {
+                    continue;
+                }
+
+                foreach (var root in scene.GetRootGameObjects())
+                {
+                    yield return root;
+                }
+            }
+        }
+
+        private static IEnumerable<GameObject> Children(GameObject go)
+        {
+            foreach (Transform child in go.transform)
+            {
+                yield return child.gameObject;
+            }
+        }
+
+        private static GameObject MatchSegment(IEnumerable<GameObject> level, string segment)
+        {
+            var name = segment;
+            var wanted = 0;
+
+            var bracket = segment.LastIndexOf('[');
+
+            if (bracket > 0 && segment.EndsWith("]") &&
+                int.TryParse(segment.Substring(bracket + 1, segment.Length - bracket - 2), out var parsed))
+            {
+                name = segment.Substring(0, bracket);
+                wanted = parsed;
+            }
+
+            var seen = 0;
+
+            foreach (var candidate in level)
+            {
+                if (candidate.name != name)
+                {
+                    continue;
+                }
+
+                if (seen == wanted)
+                {
+                    return candidate;
+                }
+
+                seen++;
+            }
+
+            return null;
+        }
+
+        private static string Segment(Transform t)
+        {
+            var siblings = t.parent == null
+                ? SceneRootsOf(t)
+                : t.parent.Cast<Transform>();
+
+            var index = 0;
+            var duplicates = 0;
+
+            foreach (var sibling in siblings)
+            {
+                if (sibling.name != t.name)
+                {
+                    continue;
+                }
+
+                if (sibling == t)
+                {
+                    index = duplicates;
+                }
+
+                duplicates++;
+            }
+
+            return duplicates > 1 ? $"{t.name}[{index}]" : t.name;
+        }
+
+        private static IEnumerable<Transform> SceneRootsOf(Transform t)
+        {
+            return SceneRoots().Select(go => go.transform);
+        }
+
+        private static bool TypeMatches(System.Type type, string typeName)
+        {
+            for (var t = type; t != null; t = t.BaseType)
+            {
+                if (t.Name == typeName || t.FullName == typeName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string NotFoundMessage(string path, string[] segments, int depth, IEnumerable<GameObject> level)
+        {
+            var available = level.Select(g => g.name).Distinct().Take(12).ToArray();
+            var where = depth == 0
+                ? "among the scene roots"
+                : $"under '{string.Join("/", segments.Take(depth))}'";
+
+            var listing = available.Length == 0
+                ? "nothing is there"
+                : string.Join(", ", available);
+
+            return $"'{path}' does not resolve: no '{segments[depth]}' {where}. Found: {listing}. " +
+                   "Paths come from scene_browse_hierarchy; inactive objects are included.";
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ObjectResolve.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ObjectResolve.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de8c83d175b0dc24fbac637d1f7c1df2

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs
@@ -1,0 +1,239 @@
+using System;
+using System.IO;
+
+using Newtonsoft.Json.Linq;
+
+using UnityEditor;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Making prefabs, placing them, and pushing instance edits back.
+    /// </summary>
+    internal static class PrefabTools
+    {
+        [McpTool(
+            "prefab_create",
+            "Save a scene object as a prefab asset. The scene object becomes an instance of it " +
+            "unless asked otherwise.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Create Prefab")]
+        public static JObject Create(
+            [McpArg("object_path", "Hierarchy path, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null,
+            [McpArg("path", "Where to save it, e.g. Assets/Prefabs/Enemy.prefab.")]
+            string path = null,
+            [McpArg("connect", "Leave the scene object linked to the new prefab.")]
+            bool connect = true,
+            [McpArg("overwrite", "Replace an existing prefab at that path.")]
+            bool overwrite = false)
+        {
+            var go = ObjectResolve.Object(objectPath, instanceId);
+            var target = RequireAssetPath(path, ".prefab");
+
+            if (!overwrite && AssetDatabase.LoadAssetAtPath<GameObject>(target) != null)
+            {
+                throw new McpToolException(
+                    "conflict",
+                    $"A prefab already exists at '{target}'. Pass overwrite to replace it — doing so " +
+                    "rewrites every instance of it in every scene.",
+                    409);
+            }
+
+            var prefab = connect
+                ? PrefabUtility.SaveAsPrefabAssetAndConnect(go, target, InteractionMode.UserAction, out var saved)
+                : PrefabUtility.SaveAsPrefabAsset(go, target, out saved);
+
+            if (!saved || prefab == null)
+            {
+                throw new McpToolException(
+                    "tool_failed",
+                    $"Unity would not save '{go.name}' as a prefab. An object that is already part of " +
+                    "another prefab's contents cannot be saved on its own.");
+            }
+
+            return new JObject
+            {
+                ["path"] = target,
+                ["guid"] = AssetDatabase.AssetPathToGUID(target),
+                ["connected"] = connect,
+                ["source"] = ObjectResolve.PathOf(go),
+            };
+        }
+
+        [McpTool(
+            "prefab_instantiate",
+            "Place a prefab into the open scene.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Instantiate Prefab")]
+        public static JObject Instantiate(
+            [McpArg("path", "Project path of the prefab asset.")]
+            string path = null,
+            [McpArg("parent_path", "Hierarchy path of the parent; omit for the scene root.")]
+            string parentPath = null,
+            [McpArg("parent_instance_id", "Parent by instance id.")]
+            int? parentInstanceId = null,
+            [McpArg("name", "Name for the instance. Defaults to the prefab's name.")]
+            string name = null,
+            [McpArg("position", "Local position, as {x, y, z}.")]
+            JObject position = null,
+            [McpArg("rotation", "Local euler angles, as {x, y, z}.")]
+            JObject rotation = null)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", "'path' is required.");
+            }
+
+            var normalised = path.Replace('\\', '/');
+            var asset = AssetDatabase.LoadAssetAtPath<GameObject>(normalised);
+
+            if (asset == null)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"No prefab at '{path}'. asset_find with type 'Prefab' will list them.");
+            }
+
+            Transform parent = null;
+
+            if (!string.IsNullOrWhiteSpace(parentPath) || parentInstanceId.HasValue)
+            {
+                parent = ObjectResolve.Object(parentPath, parentInstanceId, "parent_path").transform;
+            }
+
+            var instance = (GameObject)PrefabUtility.InstantiatePrefab(asset, parent);
+
+            if (instance == null)
+            {
+                throw new McpToolException("tool_failed", $"Unity would not instantiate '{normalised}'.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                instance.name = name;
+            }
+
+            Undo.RegisterCreatedObjectUndo(instance, "MCP Instantiate Prefab");
+
+            if (position != null)
+            {
+                instance.transform.localPosition = ReadVector(position, instance.transform.localPosition, "position");
+            }
+
+            if (rotation != null)
+            {
+                instance.transform.localEulerAngles =
+                    ReadVector(rotation, instance.transform.localEulerAngles, "rotation");
+            }
+
+            Selection.activeGameObject = instance;
+
+            return new JObject
+            {
+                ["name"] = instance.name,
+                ["path"] = ObjectResolve.PathOf(instance),
+                ["instanceId"] = instance.GetInstanceID(),
+                ["prefab"] = normalised,
+            };
+        }
+
+        [McpTool(
+            "prefab_apply",
+            "Push a prefab instance's overrides back into the prefab asset. This changes every other " +
+            "instance too, so check prefab_status first if that matters.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject Apply(
+            [McpArg("object_path", "Hierarchy path of the instance, from scene_browse_hierarchy.")]
+            string objectPath = null,
+            [McpArg("instance_id", "Instance id, instead of a path.")]
+            int? instanceId = null)
+        {
+            var go = ObjectResolve.Object(objectPath, instanceId);
+            var root = PrefabUtility.GetOutermostPrefabInstanceRoot(go);
+
+            if (root == null)
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    $"'{ObjectResolve.PathOf(go)}' is not part of a prefab instance.");
+            }
+
+            var assetPath = PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot(root);
+
+            // Applying is not on the undo stack and rewrites an asset every instance shares.
+            // Reporting the count is the only warning a caller gets.
+            var overrides = PrefabUtility.GetObjectOverrides(root).Count
+                            + PrefabUtility.GetAddedComponents(root).Count
+                            + PrefabUtility.GetAddedGameObjects(root).Count;
+
+            PrefabUtility.ApplyPrefabInstance(root, InteractionMode.UserAction);
+
+            return new JObject
+            {
+                ["applied"] = true,
+                ["instance"] = ObjectResolve.PathOf(root),
+                ["prefab"] = assetPath,
+                ["overridesApplied"] = overrides,
+                ["note"] = "Not undoable, and every instance of this prefab now carries the change.",
+            };
+        }
+
+        private static string RequireAssetPath(string path, string extension)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", "'path' is required.");
+            }
+
+            var target = path.Replace('\\', '/');
+
+            if (!target.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+            {
+                target += extension;
+            }
+
+            var parent = Path.GetDirectoryName(target)?.Replace('\\', '/');
+
+            if (!string.IsNullOrEmpty(parent) && !AssetDatabase.IsValidFolder(parent))
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"'{parent}' does not exist. Create it with asset_create_folder first.");
+            }
+
+            return target;
+        }
+
+        private static Vector3 ReadVector(JObject source, Vector3 fallback, string argumentName)
+        {
+            float Axis(string key, float current)
+            {
+                var token = source[key];
+
+                if (token == null || token.Type == JTokenType.Null)
+                {
+                    return current;
+                }
+
+                if (token.Type != JTokenType.Float && token.Type != JTokenType.Integer)
+                {
+                    throw new McpToolException(
+                        "invalid_params",
+                        $"'{argumentName}.{key}' must be a number, not {token.Type}.");
+                }
+
+                return token.Value<float>();
+            }
+
+            return new Vector3(Axis("x", fallback.x), Axis("y", fallback.y), Axis("z", fallback.z));
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs
@@ -136,13 +136,13 @@ namespace UnityMCP.Editor.Tools
 
             Selection.activeGameObject = instance;
 
-            return new JObject
+            return EditorNotes.SceneChange(new JObject
             {
                 ["name"] = instance.name,
                 ["path"] = ObjectResolve.PathOf(instance),
                 ["instanceId"] = instance.GetInstanceID(),
                 ["prefab"] = normalised,
-            };
+            });
         }
 
         [McpTool(

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7fa79ceb7c9166e429c17eaace087fc2

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs
@@ -1,0 +1,471 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Newtonsoft.Json.Linq;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Reading live private state out of a running pipeline.
+    /// </summary>
+    /// <remarks>
+    /// Render pipeline debugging spends most of its time asking what some manager's per-camera
+    /// state actually contains this frame, and the answer is always behind a private field. Doing
+    /// that through execute_code means writing, compiling and loading an assembly per question,
+    /// which is slow, is not on the undo stack, and puts a compile error between the question and
+    /// the answer. This asks directly.
+    /// <para>
+    /// Reads only. Fields and parameterless property getters, never methods, so a question cannot
+    /// change what it is asking about.
+    /// </para>
+    /// </remarks>
+    internal static class ReflectTools
+    {
+        private const BindingFlags AllStatic =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+
+        private const BindingFlags AllInstance =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy;
+
+        [McpTool(
+            "reflect_read",
+            "Read live state by type and member path, including private ones: " +
+            "'MyPipeline.ShadowManager/ByCamera[0]/levels[2]/worldToShadow'. Segments are separated " +
+            "by '/', indexers by [n] or [\"key\"]. Use this instead of execute_code when the question " +
+            "is what a value currently is.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject Read(
+            [McpArg("path", "Type name, then members: 'Namespace.Type/field/other[3]'.")]
+            string path = null,
+            [McpArg("depth", "How deep to serialise nested objects.")]
+            int depth = 2,
+            [McpArg("max_items", "Maximum elements to include from any one collection.")]
+            int maxItems = 20,
+            [McpArg("members", "Instead of a value, list the members available at this path.")]
+            bool members = false)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    "'path' is required, e.g. 'UnityEngine.QualitySettings/renderPipeline'.");
+            }
+
+            var segments = SplitPath(path);
+            var type = ResolveType(segments[0]);
+            object current = null;
+            var walked = segments[0].Raw;
+
+            for (var i = 1; i < segments.Count; i++)
+            {
+                var step = segments[i];
+
+                current = i == 1
+                    ? ReadMember(type, null, step, walked)
+                    : ReadMember(current?.GetType(), current, step, walked);
+
+                walked += "/" + step.Raw;
+
+                if (current == null && i < segments.Count - 1)
+                {
+                    throw new McpToolException("not_found", $"'{walked}' is null; cannot go further.");
+                }
+            }
+
+            if (members)
+            {
+                var owningType = current?.GetType() ?? type;
+
+                return new JObject
+                {
+                    ["path"] = walked,
+                    ["type"] = owningType.FullName,
+                    ["members"] = new JArray(MemberNames(owningType).Cast<object>().ToArray()),
+                };
+            }
+
+            return new JObject
+            {
+                ["path"] = walked,
+                ["type"] = current?.GetType().FullName,
+                ["value"] = Serialize(current, Math.Max(depth, 0), Math.Max(maxItems, 0)),
+            };
+        }
+
+        [McpTool(
+            "reflect_find_type",
+            "Find loaded types by name, when the full name for reflect_read is not known.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject FindType(
+            [McpArg("name", "Name or fragment to match, case-insensitive.")]
+            string name = null,
+            [McpArg("limit", "Maximum matches to return.")]
+            int limit = 30)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new McpToolException("invalid_params", "'name' is required.");
+            }
+
+            var matches = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(SafeTypes)
+                .Where(t => t.FullName != null &&
+                            t.FullName.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0)
+                .OrderBy(t => t.FullName.Length)
+                .Take(Math.Max(limit, 0))
+                .Select(t => (object)new JObject
+                {
+                    ["fullName"] = t.FullName,
+                    ["assembly"] = t.Assembly.GetName().Name,
+                })
+                .ToArray();
+
+            return new JObject { ["count"] = matches.Length, ["types"] = new JArray(matches) };
+        }
+
+        // ── path parsing ──
+
+        internal sealed class Segment
+        {
+            public string Raw;
+
+            public string Name;
+
+            public string Index;
+        }
+
+        internal static List<Segment> SplitPath(string path)
+        {
+            var result = new List<Segment>();
+
+            foreach (var raw in path.Split('/'))
+            {
+                if (raw.Length == 0)
+                {
+                    continue;
+                }
+
+                var segment = new Segment { Raw = raw, Name = raw };
+                var open = raw.IndexOf('[');
+
+                if (open > 0 && raw.EndsWith("]", StringComparison.Ordinal))
+                {
+                    segment.Name = raw.Substring(0, open);
+                    segment.Index = raw.Substring(open + 1, raw.Length - open - 2).Trim('"', '\'');
+                }
+
+                result.Add(segment);
+            }
+
+            if (result.Count == 0)
+            {
+                throw new McpToolException("invalid_params", $"'{path}' does not name anything.");
+            }
+
+            return result;
+        }
+
+        internal static Type ResolveType(Segment segment)
+        {
+            var candidates = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(SafeTypes)
+                .Where(t => t.FullName == segment.Name || t.Name == segment.Name)
+                .OrderBy(t => t.FullName == segment.Name ? 0 : 1)
+                .ToArray();
+
+            if (candidates.Length == 0)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"No loaded type named '{segment.Name}'. reflect_find_type will search for it.");
+            }
+
+            if (candidates.Length > 1 && candidates[0].FullName != segment.Name)
+            {
+                var names = string.Join(", ", candidates.Take(5).Select(t => t.FullName));
+
+                throw new McpToolException(
+                    "invalid_params",
+                    $"'{segment.Name}' is ambiguous: {names}. Use the full name.");
+            }
+
+            return candidates[0];
+        }
+
+        private static object ReadMember(Type type, object instance, Segment segment, string walked)
+        {
+            if (type == null)
+            {
+                throw new McpToolException("not_found", $"'{walked}' is null; cannot read '{segment.Name}'.");
+            }
+
+            var flags = instance == null ? AllStatic : AllInstance;
+            object value = null;
+            var found = false;
+
+            for (var t = type; t != null && !found; t = t.BaseType)
+            {
+                var field = t.GetField(segment.Name, flags);
+
+                if (field != null)
+                {
+                    value = field.GetValue(instance);
+                    found = true;
+                    break;
+                }
+
+                var property = t.GetProperty(segment.Name, flags);
+
+                if (property != null && property.CanRead && property.GetIndexParameters().Length == 0)
+                {
+                    value = property.GetValue(instance);
+                    found = true;
+                }
+            }
+
+            if (!found)
+            {
+                var available = string.Join(", ", MemberNames(type).Take(15));
+
+                throw new McpToolException(
+                    "not_found",
+                    $"'{type.FullName}' has no readable member '{segment.Name}'. Available: {available}. " +
+                    "Pass members=true to list them all.");
+            }
+
+            return segment.Index == null ? value : Index(value, segment.Index, walked + "/" + segment.Raw);
+        }
+
+        private static object Index(object value, string index, string walked)
+        {
+            if (value == null)
+            {
+                throw new McpToolException("not_found", $"'{walked}' is null; cannot index it.");
+            }
+
+            if (value is IDictionary dictionary)
+            {
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    if (string.Equals(entry.Key?.ToString(), index, StringComparison.Ordinal))
+                    {
+                        return entry.Value;
+                    }
+                }
+
+                var keys = string.Join(", ", dictionary.Keys.Cast<object>().Take(10).Select(k => k?.ToString()));
+
+                throw new McpToolException(
+                    "not_found",
+                    $"No key '{index}' in {walked}. Keys: {keys}.");
+            }
+
+            if (!int.TryParse(index, out var position))
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    $"'{index}' is not a number, and {walked} is not a dictionary.");
+            }
+
+            if (value is IList list)
+            {
+                if (position < 0 || position >= list.Count)
+                {
+                    throw new McpToolException(
+                        "invalid_params",
+                        $"Index {position} is out of range; {walked} has {list.Count} element(s).");
+                }
+
+                return list[position];
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                var i = 0;
+
+                foreach (var item in enumerable)
+                {
+                    if (i++ == position)
+                    {
+                        return item;
+                    }
+                }
+
+                throw new McpToolException("invalid_params", $"Index {position} is past the end of {walked}.");
+            }
+
+            throw new McpToolException("invalid_params", $"{walked} is not indexable.");
+        }
+
+        internal static IEnumerable<string> MemberNames(Type type)
+        {
+            var names = new List<string>();
+
+            for (var t = type; t != null && t != typeof(object); t = t.BaseType)
+            {
+                names.AddRange(t.GetFields(AllStatic).Select(f => f.Name));
+                names.AddRange(t.GetFields(AllInstance).Select(f => f.Name));
+                names.AddRange(t.GetProperties(AllStatic)
+                    .Where(p => p.CanRead && p.GetIndexParameters().Length == 0).Select(p => p.Name));
+                names.AddRange(t.GetProperties(AllInstance)
+                    .Where(p => p.CanRead && p.GetIndexParameters().Length == 0).Select(p => p.Name));
+            }
+
+            return names.Distinct().OrderBy(n => n, StringComparer.Ordinal);
+        }
+
+        // ── serialisation ──
+
+        internal static JToken Serialize(object value, int depth, int maxItems)
+        {
+            switch (value)
+            {
+                case null:
+                    return JValue.CreateNull();
+
+                case string s:
+                    return s;
+
+                case bool b:
+                    return b;
+
+                case float f:
+                    return f;
+
+                case double d:
+                    return d;
+
+                case decimal m:
+                    return m;
+
+                case Enum e:
+                    return e.ToString();
+            }
+
+            var type = value.GetType();
+
+            if (type.IsPrimitive)
+            {
+                return JToken.FromObject(value);
+            }
+
+            if (value is Vector2 v2) return new JObject { ["x"] = v2.x, ["y"] = v2.y };
+            if (value is Vector3 v3) return new JObject { ["x"] = v3.x, ["y"] = v3.y, ["z"] = v3.z };
+            if (value is Vector4 v4) return new JObject { ["x"] = v4.x, ["y"] = v4.y, ["z"] = v4.z, ["w"] = v4.w };
+            if (value is Color c) return new JObject { ["r"] = c.r, ["g"] = c.g, ["b"] = c.b, ["a"] = c.a };
+
+            if (value is Matrix4x4 matrix)
+            {
+                var rows = new JArray();
+
+                for (var r = 0; r < 4; r++)
+                {
+                    rows.Add(new JArray(
+                        (object)matrix[r, 0], (object)matrix[r, 1], (object)matrix[r, 2], (object)matrix[r, 3]));
+                }
+
+                return rows;
+            }
+
+            if (value is UnityEngine.Object unityObject)
+            {
+                return new JObject
+                {
+                    ["name"] = unityObject.name,
+                    ["type"] = type.FullName,
+                    ["instanceId"] = unityObject.GetInstanceID(),
+                };
+            }
+
+            if (depth <= 0)
+            {
+                // Not silently truncated to null: a caller that wanted more can ask for more.
+                return new JObject { ["type"] = type.FullName, ["truncated"] = "depth" };
+            }
+
+            if (value is IDictionary dictionary)
+            {
+                var o = new JObject();
+                var n = 0;
+
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    if (n++ >= maxItems)
+                    {
+                        o["__truncated"] = $"{dictionary.Count} entries";
+                        break;
+                    }
+
+                    o[entry.Key?.ToString() ?? "null"] = Serialize(entry.Value, depth - 1, maxItems);
+                }
+
+                return o;
+            }
+
+            if (value is IEnumerable sequence)
+            {
+                var a = new JArray();
+                var n = 0;
+                var more = false;
+
+                foreach (var item in sequence)
+                {
+                    if (n++ >= maxItems)
+                    {
+                        more = true;
+                        break;
+                    }
+
+                    a.Add(Serialize(item, depth - 1, maxItems));
+                }
+
+                if (!more)
+                {
+                    return a;
+                }
+
+                return new JObject { ["items"] = a, ["truncated"] = $"more than {maxItems}" };
+            }
+
+            var result = new JObject { ["__type"] = type.FullName };
+
+            foreach (var field in type.GetFields(AllInstance).Take(60))
+            {
+                try
+                {
+                    result[field.Name] = Serialize(field.GetValue(value), depth - 1, maxItems);
+                }
+                catch (Exception e)
+                {
+                    result[field.Name] = $"<{e.GetType().Name}>";
+                }
+            }
+
+            return result;
+        }
+
+        internal static Type[] SafeTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                return e.Types.Where(t => t != null).ToArray();
+            }
+            catch
+            {
+                return Array.Empty<Type>();
+            }
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs
@@ -59,26 +59,7 @@ namespace UnityMCP.Editor.Tools
                     "'path' is required, e.g. 'UnityEngine.QualitySettings/renderPipeline'.");
             }
 
-            var segments = SplitPath(path);
-            var type = ResolveType(segments[0]);
-            object current = null;
-            var walked = segments[0].Raw;
-
-            for (var i = 1; i < segments.Count; i++)
-            {
-                var step = segments[i];
-
-                current = i == 1
-                    ? ReadMember(type, null, step, walked)
-                    : ReadMember(current?.GetType(), current, step, walked);
-
-                walked += "/" + step.Raw;
-
-                if (current == null && i < segments.Count - 1)
-                {
-                    throw new McpToolException("not_found", $"'{walked}' is null; cannot go further.");
-                }
-            }
+            var current = ResolvePath(path, out var type, out var walked);
 
             if (members)
             {
@@ -129,6 +110,39 @@ namespace UnityMCP.Editor.Tools
                 .ToArray();
 
             return new JObject { ["count"] = matches.Length, ["types"] = new JArray(matches) };
+        }
+
+        /// <summary>
+        /// Walks a type-and-member path and returns whatever it lands on.
+        /// </summary>
+        /// <remarks>
+        /// Shared with gpu_readback, which needs the same walk to reach the buffer or texture it
+        /// is asked to read. Two implementations of "what does this path mean" would drift.
+        /// </remarks>
+        internal static object ResolvePath(string path, out Type rootType, out string walked)
+        {
+            var segments = SplitPath(path);
+            rootType = ResolveType(segments[0]);
+            object current = null;
+            walked = segments[0].Raw;
+
+            for (var i = 1; i < segments.Count; i++)
+            {
+                var step = segments[i];
+
+                current = i == 1
+                    ? ReadMember(rootType, null, step, walked)
+                    : ReadMember(current?.GetType(), current, step, walked);
+
+                walked += "/" + step.Raw;
+
+                if (current == null && i < segments.Count - 1)
+                {
+                    throw new McpToolException("not_found", $"'{walked}' is null; cannot go further.");
+                }
+            }
+
+            return current;
         }
 
         // ── path parsing ──

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ad8875ffbdca3d4eba4c1931df03dd3

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
@@ -1,0 +1,300 @@
+using System;
+using System.IO;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using UnityEditor;
+
+using UnityEngine;
+using UnityEngine.Rendering;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Answering "is the picture right", and "what is drawing it".
+    /// </summary>
+    internal static class RenderTools
+    {
+        [McpTool(
+            "render_compare",
+            "Compare two captured images and report how they differ, in numbers. Use this instead of " +
+            "looking at both pictures: capture with save_path, toggle the thing under test, capture " +
+            "again, then compare. Absolute colours are post-tonemap and not worth trusting, so what " +
+            "this reports is change — how many pixels moved, by how much, and where.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject Compare(
+            [McpArg("before", "Path to the first PNG, from capture_screenshot's save_path.")]
+            string before = null,
+            [McpArg("after", "Path to the second PNG.")]
+            string after = null,
+            [McpArg("threshold", "Per-channel difference, 0-255, below which a pixel counts as unchanged.")]
+            int threshold = 2,
+            [McpArg("grid", "Report the difference over a grid this many cells across, to localise it.")]
+            int grid = 8)
+        {
+            var a = LoadPng(before, "before");
+            var b = LoadPng(after, "after");
+
+            if (a.width != b.width || a.height != b.height)
+            {
+                // Read the sizes before destroying: interpolating them afterwards throws
+                // MissingReferenceException and the caller gets tool_failed instead of the
+                // explanation.
+                var sizes = $"{a.width}x{a.height} and {b.width}x{b.height}";
+
+                UnityEngine.Object.DestroyImmediate(a);
+                UnityEngine.Object.DestroyImmediate(b);
+
+                throw new McpToolException(
+                    "invalid_params",
+                    $"The images are different sizes ({sizes}). " +
+                    "Capture both at the same size, or the comparison means nothing.");
+            }
+
+            try
+            {
+                var pa = a.GetPixels32();
+                var pb = b.GetPixels32();
+
+                var cells = Math.Max(1, Math.Min(grid, 32));
+                var cellCounts = new int[cells * cells];
+
+                long changed = 0;
+                long sumDelta = 0;
+                var maxDelta = 0;
+                int minX = a.width, minY = a.height, maxX = -1, maxY = -1;
+
+                for (var i = 0; i < pa.Length; i++)
+                {
+                    var dr = Math.Abs(pa[i].r - pb[i].r);
+                    var dg = Math.Abs(pa[i].g - pb[i].g);
+                    var db = Math.Abs(pa[i].b - pb[i].b);
+                    var delta = Math.Max(dr, Math.Max(dg, db));
+
+                    if (delta <= threshold)
+                    {
+                        continue;
+                    }
+
+                    changed++;
+                    sumDelta += delta;
+                    maxDelta = Math.Max(maxDelta, delta);
+
+                    var x = i % a.width;
+                    var y = i / a.width;
+
+                    if (x < minX) minX = x;
+                    if (x > maxX) maxX = x;
+                    if (y < minY) minY = y;
+                    if (y > maxY) maxY = y;
+
+                    cellCounts[(y * cells / a.height) * cells + (x * cells / a.width)]++;
+                }
+
+                var total = (long)a.width * a.height;
+
+                var result = new JObject
+                {
+                    ["width"] = a.width,
+                    ["height"] = a.height,
+                    ["totalPixels"] = total,
+                    ["changedPixels"] = changed,
+                    ["changedRatio"] = total == 0 ? 0d : Math.Round((double)changed / total, 6),
+                    ["identical"] = changed == 0,
+                    ["meanDelta"] = changed == 0 ? 0d : Math.Round((double)sumDelta / changed, 2),
+                    ["maxDelta"] = maxDelta,
+                    ["threshold"] = threshold,
+                };
+
+                if (changed > 0)
+                {
+                    result["boundingBox"] = new JObject
+                    {
+                        ["x"] = minX,
+                        ["y"] = minY,
+                        ["width"] = maxX - minX + 1,
+                        ["height"] = maxY - minY + 1,
+                    };
+
+                    // A grid of counts is a picture of where the change is, in a few dozen numbers
+                    // rather than a few hundred kilobytes. Rows run top to bottom.
+                    var rows = new JArray();
+                    var cellPixels = Math.Max(1, (a.width / cells) * (a.height / cells));
+
+                    for (var row = cells - 1; row >= 0; row--)
+                    {
+                        var cols = new JArray();
+
+                        for (var col = 0; col < cells; col++)
+                        {
+                            cols.Add(Math.Round((double)cellCounts[row * cells + col] / cellPixels, 3));
+                        }
+
+                        rows.Add(cols);
+                    }
+
+                    result["gridChangedRatio"] = rows;
+                }
+
+                return result;
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(a);
+                UnityEngine.Object.DestroyImmediate(b);
+            }
+        }
+
+        [McpTool(
+            "render_pipeline_info",
+            "Report what is actually drawing: the render pipeline asset in force, colour space, HDR, " +
+            "MSAA, graphics API and quality level. Read this first when a shader behaves differently " +
+            "than expected — the quality level's pipeline override is a common surprise.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject PipelineInfo()
+        {
+            var quality = QualitySettings.renderPipeline;
+            var graphics = GraphicsSettings.defaultRenderPipeline;
+            var active = quality != null ? quality : graphics;
+
+            return new JObject
+            {
+                ["activePipeline"] = active == null ? "Built-in" : active.GetType().Name,
+                ["activePipelineAsset"] = active == null ? null : (JToken)AssetDatabase.GetAssetPath(active),
+                // Two places can name a pipeline and the quality level wins. Reporting both is the
+                // difference between "my URP settings do nothing" being a mystery and being obvious.
+                ["defaultPipelineAsset"] = graphics == null ? null : (JToken)AssetDatabase.GetAssetPath(graphics),
+                ["qualityPipelineAsset"] = quality == null ? null : (JToken)AssetDatabase.GetAssetPath(quality),
+                ["qualityLevel"] = QualitySettings.names.ElementAtOrDefault(QualitySettings.GetQualityLevel()),
+                ["colorSpace"] = QualitySettings.activeColorSpace.ToString(),
+                ["graphicsApi"] = SystemInfo.graphicsDeviceType.ToString(),
+                ["graphicsDevice"] = SystemInfo.graphicsDeviceName,
+                ["shaderLevel"] = SystemInfo.graphicsShaderLevel,
+                ["supportsComputeShaders"] = SystemInfo.supportsComputeShaders,
+                ["antiAliasing"] = QualitySettings.antiAliasing,
+                ["anisotropicFiltering"] = QualitySettings.anisotropicFiltering.ToString(),
+                ["shadowResolution"] = QualitySettings.shadowResolution.ToString(),
+                ["shadowDistance"] = QualitySettings.shadowDistance,
+                ["activeBuildTarget"] = EditorUserBuildSettings.activeBuildTarget.ToString(),
+                ["batchingStatic"] = PlayerSettings.GetStaticBatchingForPlatform(EditorUserBuildSettings.activeBuildTarget),
+            };
+        }
+
+        [McpTool(
+            "render_camera_info",
+            "Report the cameras and their matrices. The view and projection matrices are here so a " +
+            "value read off a screenshot can be checked against one computed on the CPU — screenshot " +
+            "colours are post-tonemap and cannot settle an argument on their own.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject CameraInfo(
+            [McpArg("name", "Only report the camera with this name.")]
+            string name = null,
+            [McpArg("include_matrices", "Include the view and projection matrices, row-major.")]
+            bool includeMatrices = true)
+        {
+            var cameras = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsInactive.Include, FindObjectsSortMode.None)
+                .Where(c => string.IsNullOrWhiteSpace(name) || c.name == name)
+                .OrderByDescending(c => c.isActiveAndEnabled)
+                .ThenBy(c => c.depth)
+                .ToArray();
+
+            if (cameras.Length == 0)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    string.IsNullOrWhiteSpace(name)
+                        ? "No cameras in the open scenes."
+                        : $"No camera named '{name}'.");
+            }
+
+            var list = new JArray(cameras.Select(c =>
+            {
+                var entry = new JObject
+                {
+                    ["name"] = c.name,
+                    ["path"] = ObjectResolve.PathOf(c.gameObject),
+                    ["enabled"] = c.isActiveAndEnabled,
+                    ["depth"] = c.depth,
+                    ["orthographic"] = c.orthographic,
+                    ["fieldOfView"] = c.fieldOfView,
+                    ["nearClipPlane"] = c.nearClipPlane,
+                    ["farClipPlane"] = c.farClipPlane,
+                    ["cullingMask"] = c.cullingMask,
+                    ["clearFlags"] = c.clearFlags.ToString(),
+                    ["allowHDR"] = c.allowHDR,
+                    ["allowMSAA"] = c.allowMSAA,
+                    ["targetTexture"] = c.targetTexture == null ? null : (JToken)c.targetTexture.name,
+                    ["pixelWidth"] = c.pixelWidth,
+                    ["pixelHeight"] = c.pixelHeight,
+                };
+
+                if (includeMatrices)
+                {
+                    entry["worldToCameraMatrix"] = Matrix(c.worldToCameraMatrix);
+                    entry["projectionMatrix"] = Matrix(c.projectionMatrix);
+                    // What the shader actually receives: the platform flips and depth range are
+                    // applied here, and forgetting that is why a CPU replica disagrees.
+                    entry["gpuProjectionMatrix"] = Matrix(
+                        GL.GetGPUProjectionMatrix(c.projectionMatrix, c.targetTexture != null));
+                }
+
+                return (object)entry;
+            }).ToArray());
+
+            return new JObject
+            {
+                ["count"] = cameras.Length,
+                ["cameras"] = list,
+                ["sceneViewCameraIncluded"] = false,
+            };
+        }
+
+        private static JArray Matrix(Matrix4x4 m)
+        {
+            var rows = new JArray();
+
+            for (var r = 0; r < 4; r++)
+            {
+                rows.Add(new JArray(
+                    (object)Math.Round(m[r, 0], 6),
+                    (object)Math.Round(m[r, 1], 6),
+                    (object)Math.Round(m[r, 2], 6),
+                    (object)Math.Round(m[r, 3], 6)));
+            }
+
+            return rows;
+        }
+
+        private static Texture2D LoadPng(string path, string argumentName)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", $"'{argumentName}' is required.");
+            }
+
+            var full = Path.GetFullPath(path);
+
+            if (!File.Exists(full))
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"No file at '{path}'. Capture one with capture_screenshot and its save_path argument.");
+            }
+
+            var texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+
+            if (!texture.LoadImage(File.ReadAllBytes(full)))
+            {
+                UnityEngine.Object.DestroyImmediate(texture);
+
+                throw new McpToolException("invalid_params", $"'{path}' is not an image Unity can read.");
+            }
+
+            return texture;
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
@@ -37,7 +37,20 @@ namespace UnityMCP.Editor.Tools
             int grid = 8)
         {
             var a = LoadPng(before, "before");
-            var b = LoadPng(after, "after");
+            Texture2D b;
+
+            try
+            {
+                b = LoadPng(after, "after");
+            }
+            catch
+            {
+                // Without this the first texture outlives every failed call. A caller comparing
+                // against a path that does not exist yet — polling for a capture, say — would
+                // leak one texture per attempt and never learn why memory grew.
+                UnityEngine.Object.DestroyImmediate(a);
+                throw;
+            }
 
             if (a.width != b.width || a.height != b.height)
             {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 487854b0cb145fa4c8e924170f1e407b

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/SceneTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/SceneTools.cs
@@ -1,4 +1,13 @@
+using System;
+using System.IO;
+using System.Linq;
+
 using Newtonsoft.Json.Linq;
+
+using UnityEditor;
+using UnityEditor.SceneManagement;
+
+using UnityEngine.SceneManagement;
 
 using UnityMCP.Editor.Core;
 using UnityMCP.Editor.Core.Attributes;
@@ -6,7 +15,7 @@ using UnityMCP.Editor.Handlers;
 
 namespace UnityMCP.Editor.Tools
 {
-    /// <summary>Scene hierarchy inspection.</summary>
+    /// <summary>Inspecting and managing scenes.</summary>
     internal static class SceneTools
     {
         [McpTool(
@@ -45,6 +54,220 @@ namespace UnityMCP.Editor.Tools
                 ("limit", limit),
                 ("offset", offset),
                 ("fields", fields)));
+        }
+
+        [McpTool(
+            "scene_list",
+            "List the scenes that are open, and the ones in the build settings. Read this before " +
+            "opening anything: which scenes are loaded decides what the hierarchy tools can see.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject List()
+        {
+            var open = new JArray();
+
+            for (var i = 0; i < SceneManager.sceneCount; i++)
+            {
+                var scene = SceneManager.GetSceneAt(i);
+
+                open.Add(new JObject
+                {
+                    ["name"] = scene.name,
+                    ["path"] = scene.path,
+                    ["index"] = i,
+                    ["isLoaded"] = scene.isLoaded,
+                    ["isDirty"] = scene.isDirty,
+                    ["rootCount"] = scene.isLoaded ? scene.rootCount : 0,
+                    ["isActive"] = scene == SceneManager.GetActiveScene(),
+                });
+            }
+
+            var inBuild = new JArray(EditorBuildSettings.scenes.Select((s, i) => (object)new JObject
+            {
+                ["path"] = s.path,
+                ["enabled"] = s.enabled,
+                ["buildIndex"] = i,
+            }).ToArray());
+
+            return new JObject
+            {
+                ["open"] = open,
+                ["inBuildSettings"] = inBuild,
+                ["activeScene"] = SceneManager.GetActiveScene().path,
+            };
+        }
+
+        [McpTool(
+            "scene_open",
+            "Open a scene, replacing what is open or adding to it. Unsaved changes stop this " +
+            "rather than being discarded.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject Open(
+            [McpArg("path", "Project path of the scene, e.g. Assets/Scenes/Main.unity.")]
+            string path = null,
+            [McpArg("additive", "Add to the open scenes instead of replacing them.")]
+            bool additive = false)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", "'path' is required.");
+            }
+
+            var normalised = path.Replace('\\', '/');
+
+            if (AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(normalised) == null)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"No scene at '{path}'. Use asset_find with type 'Scene' to list them.");
+            }
+
+            // Opening on top of unsaved work would throw it away with nothing to undo. Refusing
+            // and naming the scenes is recoverable; a silent discard is not.
+            if (!additive)
+            {
+                var dirty = OpenScenes().Where(s => s.isDirty).Select(s => s.name).ToArray();
+
+                if (dirty.Length > 0)
+                {
+                    throw new McpToolException(
+                        "conflict",
+                        $"Unsaved changes in: {string.Join(", ", dirty)}. Call scene_save first, or " +
+                        "open additively.",
+                        409);
+                }
+            }
+
+            var scene = EditorSceneManager.OpenScene(
+                normalised,
+                additive ? OpenSceneMode.Additive : OpenSceneMode.Single);
+
+            return new JObject
+            {
+                ["opened"] = true,
+                ["name"] = scene.name,
+                ["path"] = scene.path,
+                ["additive"] = additive,
+                ["rootCount"] = scene.rootCount,
+            };
+        }
+
+        [McpTool(
+            "scene_save",
+            "Save open scenes. Saves every dirty scene by default.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject Save(
+            [McpArg("path", "Save the active scene to this path instead, as a copy (Save As).")]
+            string path = null)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                var target = path.Replace('\\', '/');
+                var parent = Path.GetDirectoryName(target)?.Replace('\\', '/');
+
+                if (!string.IsNullOrEmpty(parent) && !AssetDatabase.IsValidFolder(parent))
+                {
+                    throw new McpToolException(
+                        "not_found",
+                        $"'{parent}' does not exist. Create it with asset_create_folder first.");
+                }
+
+                var active = SceneManager.GetActiveScene();
+
+                if (!EditorSceneManager.SaveScene(active, target))
+                {
+                    throw new McpToolException("tool_failed", $"Unity would not save '{active.name}' to '{target}'.");
+                }
+
+                return new JObject { ["saved"] = new JArray(target) };
+            }
+
+            var dirty = OpenScenes().Where(s => s.isDirty).ToArray();
+
+            if (dirty.Length == 0)
+            {
+                return new JObject { ["saved"] = new JArray(), ["note"] = "Nothing was modified." };
+            }
+
+            if (!EditorSceneManager.SaveOpenScenes())
+            {
+                throw new McpToolException("tool_failed", "Unity would not save the open scenes.");
+            }
+
+            return new JObject
+            {
+                ["saved"] = new JArray(dirty.Select(s => (object)(string.IsNullOrEmpty(s.path) ? s.name : s.path)).ToArray()),
+            };
+        }
+
+        [McpTool(
+            "scene_create",
+            "Create a new scene and open it.",
+            Idempotency = McpIdempotency.Unsafe)]
+        public static JObject Create(
+            [McpArg("path", "Where to save it, e.g. Assets/Scenes/New.unity. Omit to leave it unsaved.")]
+            string path = null,
+            [McpArg("empty", "Create it without the default camera and light.")]
+            bool empty = false,
+            [McpArg("additive", "Add to the open scenes instead of replacing them.")]
+            bool additive = false)
+        {
+            if (!additive)
+            {
+                var dirty = OpenScenes().Where(s => s.isDirty).Select(s => s.name).ToArray();
+
+                if (dirty.Length > 0)
+                {
+                    throw new McpToolException(
+                        "conflict",
+                        $"Unsaved changes in: {string.Join(", ", dirty)}. Call scene_save first, or " +
+                        "create additively.",
+                        409);
+                }
+            }
+
+            var scene = EditorSceneManager.NewScene(
+                empty ? NewSceneSetup.EmptyScene : NewSceneSetup.DefaultGameObjects,
+                additive ? NewSceneMode.Additive : NewSceneMode.Single);
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return new JObject
+                {
+                    ["created"] = true,
+                    ["name"] = scene.name,
+                    ["path"] = null,
+                    ["note"] = "Not saved to disk. Call scene_save with a path to keep it.",
+                };
+            }
+
+            var target = path.Replace('\\', '/');
+            var parent = Path.GetDirectoryName(target)?.Replace('\\', '/');
+
+            if (!string.IsNullOrEmpty(parent) && !AssetDatabase.IsValidFolder(parent))
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"'{parent}' does not exist. Create it with asset_create_folder first.");
+            }
+
+            if (!EditorSceneManager.SaveScene(scene, target))
+            {
+                throw new McpToolException("tool_failed", $"Unity would not save the new scene to '{target}'.");
+            }
+
+            return new JObject { ["created"] = true, ["name"] = scene.name, ["path"] = target };
+        }
+
+        private static Scene[] OpenScenes()
+        {
+            var scenes = new Scene[SceneManager.sceneCount];
+
+            for (var i = 0; i < scenes.Length; i++)
+            {
+                scenes[i] = SceneManager.GetSceneAt(i);
+            }
+
+            return scenes;
         }
     }
 }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ShaderTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ShaderTools.cs
@@ -1,0 +1,432 @@
+using System;
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using UnityEditor;
+
+using UnityEditor.Rendering;
+
+using UnityEngine;
+using UnityEngine.Rendering;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+namespace UnityMCP.Editor.Tools
+{
+    /// <summary>
+    /// Shaders and materials: what they compiled to, and what they are set to.
+    /// </summary>
+    internal static class ShaderTools
+    {
+        [McpTool(
+            "shader_errors",
+            "Report shader compilation errors and warnings. A shader that fails to compile does not " +
+            "stop the Editor or show up in the console after the fact — it renders magenta and stays " +
+            "quiet, so this has to be asked for. Omit the path to sweep every shader in the project.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject Errors(
+            [McpArg("path", "Shader asset path. Omit to check every shader in the project.")]
+            string path = null,
+            [McpArg("include_warnings", "Report warnings as well as errors.")]
+            bool includeWarnings = false,
+            [McpArg("limit", "Maximum messages to return.")]
+            int limit = 50)
+        {
+            var shaders = string.IsNullOrWhiteSpace(path)
+                ? AssetDatabase.FindAssets("t:Shader")
+                    .Select(AssetDatabase.GUIDToAssetPath)
+                    .Where(p => p.StartsWith("Assets/", StringComparison.Ordinal))
+                    .Select(AssetDatabase.LoadAssetAtPath<Shader>)
+                    .Where(s => s != null)
+                    .ToArray()
+                : new[] { RequireShader(path) };
+
+            var messages = new JArray();
+            var errorCount = 0;
+            var warningCount = 0;
+
+            foreach (var shader in shaders)
+            {
+                var count = ShaderUtil.GetShaderMessageCount(shader);
+
+                if (count == 0)
+                {
+                    continue;
+                }
+
+                foreach (var message in ShaderUtil.GetShaderMessages(shader))
+                {
+                    var isError = message.severity == ShaderCompilerMessageSeverity.Error;
+
+                    if (isError)
+                    {
+                        errorCount++;
+                    }
+                    else
+                    {
+                        warningCount++;
+                    }
+
+                    if (!isError && !includeWarnings)
+                    {
+                        continue;
+                    }
+
+                    if (messages.Count >= Math.Max(limit, 0))
+                    {
+                        continue;
+                    }
+
+                    messages.Add(new JObject
+                    {
+                        ["shader"] = AssetDatabase.GetAssetPath(shader),
+                        ["severity"] = isError ? "error" : "warning",
+                        ["message"] = message.message,
+                        ["messageDetails"] = string.IsNullOrEmpty(message.messageDetails) ? null : message.messageDetails,
+                        ["file"] = message.file,
+                        ["line"] = message.line,
+                        ["platform"] = message.platform.ToString(),
+                    });
+                }
+            }
+
+            return new JObject
+            {
+                ["shadersChecked"] = shaders.Length,
+                ["errorCount"] = errorCount,
+                ["warningCount"] = warningCount,
+                ["clean"] = errorCount == 0,
+                ["truncated"] = messages.Count >= Math.Max(limit, 0) && errorCount + warningCount > messages.Count,
+                ["messages"] = messages,
+            };
+        }
+
+        [McpTool(
+            "shader_info",
+            "Describe a shader: its passes, properties, keywords and render queue.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject Info(
+            [McpArg("path", "Shader asset path, e.g. Assets/Shaders/Toon.shader.")]
+            string path = null,
+            [McpArg("name", "Shader name as written in the Shader declaration, instead of a path.")]
+            string name = null)
+        {
+            var shader = string.IsNullOrWhiteSpace(path)
+                ? RequireShaderByName(name)
+                : RequireShader(path);
+
+            var properties = new JArray();
+
+            for (var i = 0; i < shader.GetPropertyCount(); i++)
+            {
+                properties.Add(new JObject
+                {
+                    ["name"] = shader.GetPropertyName(i),
+                    ["description"] = shader.GetPropertyDescription(i),
+                    ["type"] = shader.GetPropertyType(i).ToString(),
+                    ["flags"] = shader.GetPropertyFlags(i).ToString(),
+                });
+            }
+
+            return new JObject
+            {
+                ["name"] = shader.name,
+                ["path"] = AssetDatabase.GetAssetPath(shader),
+                ["isSupported"] = shader.isSupported,
+                ["renderQueue"] = shader.renderQueue,
+                ["maximumLOD"] = shader.maximumLOD,
+                ["passCount"] = shader.passCount,
+                ["subshaderCount"] = shader.subshaderCount,
+                ["propertyCount"] = shader.GetPropertyCount(),
+                ["properties"] = properties,
+                ["keywordSpace"] = new JArray(shader.keywordSpace.keywordNames.Cast<object>().ToArray()),
+                ["messageCount"] = ShaderUtil.GetShaderMessageCount(shader),
+            };
+        }
+
+        [McpTool(
+            "material_read",
+            "Report a material's shader, every property's current value, its enabled keywords and its " +
+            "render queue. This is the state a frame is actually drawn from, as opposed to what the " +
+            "shader declares as defaults.",
+            Idempotency = McpIdempotency.Safe)]
+        public static JObject MaterialRead(
+            [McpArg("path", "Material asset path, e.g. Assets/Art/Wood.mat.")]
+            string path = null)
+        {
+            var material = RequireMaterial(path);
+            var shader = material.shader;
+            var properties = new JArray();
+
+            for (var i = 0; i < shader.GetPropertyCount(); i++)
+            {
+                var propertyName = shader.GetPropertyName(i);
+                var type = shader.GetPropertyType(i);
+
+                JToken value;
+
+                switch (type)
+                {
+                    case ShaderPropertyType.Color:
+                        var c = material.GetColor(propertyName);
+                        value = new JObject { ["r"] = c.r, ["g"] = c.g, ["b"] = c.b, ["a"] = c.a };
+                        break;
+
+                    case ShaderPropertyType.Vector:
+                        var v = material.GetVector(propertyName);
+                        value = new JObject { ["x"] = v.x, ["y"] = v.y, ["z"] = v.z, ["w"] = v.w };
+                        break;
+
+                    case ShaderPropertyType.Float:
+                    case ShaderPropertyType.Range:
+                        value = material.GetFloat(propertyName);
+                        break;
+
+                    case ShaderPropertyType.Int:
+                        value = material.GetInteger(propertyName);
+                        break;
+
+                    case ShaderPropertyType.Texture:
+                        var texture = material.GetTexture(propertyName);
+                        value = texture == null ? null : (JToken)AssetDatabase.GetAssetPath(texture);
+                        break;
+
+                    default:
+                        value = null;
+                        break;
+                }
+
+                properties.Add(new JObject
+                {
+                    ["name"] = propertyName,
+                    ["type"] = type.ToString(),
+                    ["value"] = value,
+                });
+            }
+
+            return new JObject
+            {
+                ["path"] = AssetDatabase.GetAssetPath(material),
+                ["shader"] = shader.name,
+                ["shaderPath"] = AssetDatabase.GetAssetPath(shader),
+                ["renderQueue"] = material.renderQueue,
+                // The material's own queue is -1 when it just follows the shader. Reporting both
+                // saves a round trip when a sorting problem is being chased.
+                ["renderQueueFromShader"] = material.renderQueue == shader.renderQueue,
+                ["enabledKeywords"] = new JArray(material.enabledKeywords.Select(k => (object)k.name).ToArray()),
+                ["shaderKeywords"] = new JArray(material.shaderKeywords.Cast<object>().ToArray()),
+                ["passCount"] = material.passCount,
+                ["properties"] = properties,
+            };
+        }
+
+        [McpTool(
+            "material_set",
+            "Set one property on a material, or toggle one of its keywords. Undoable.",
+            Idempotency = McpIdempotency.Unsafe,
+            UndoGroup = "MCP Material Edit")]
+        public static JObject MaterialSet(
+            [McpArg("path", "Material asset path.")]
+            string path = null,
+            [McpArg("property", "Shader property name, e.g. _BaseColor. Omit when toggling a keyword.")]
+            string property = null,
+            [McpArg("value", "New value: a number, a string for textures, or {r,g,b,a} / {x,y,z,w}.")]
+            JToken value = null,
+            [McpArg("keyword", "Shader keyword to toggle instead of setting a property.")]
+            string keyword = null,
+            [McpArg("enabled", "Whether the keyword should be on.")]
+            bool enabled = true,
+            [McpArg("render_queue", "Override the render queue; -1 puts it back to the shader's.")]
+            int? renderQueue = null)
+        {
+            var material = RequireMaterial(path);
+
+            Undo.RecordObject(material, "MCP Material Edit");
+            var changes = new JArray();
+
+            if (!string.IsNullOrWhiteSpace(keyword))
+            {
+                if (enabled)
+                {
+                    material.EnableKeyword(keyword);
+                }
+                else
+                {
+                    material.DisableKeyword(keyword);
+                }
+
+                changes.Add($"keyword {keyword} = {enabled}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(property))
+            {
+                if (!material.HasProperty(property))
+                {
+                    throw new McpToolException(
+                        "not_found",
+                        $"'{material.shader.name}' has no property '{property}'. material_read lists them.");
+                }
+
+                if (value == null || value.Type == JTokenType.Null)
+                {
+                    throw new McpToolException("invalid_params", "'value' is required when setting a property.");
+                }
+
+                changes.Add($"{property} = {ApplyProperty(material, property, value)}");
+            }
+
+            if (renderQueue.HasValue)
+            {
+                material.renderQueue = renderQueue.Value;
+                changes.Add($"renderQueue = {renderQueue.Value}");
+            }
+
+            if (changes.Count == 0)
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    "Nothing to do: pass 'property' with 'value', 'keyword', or 'render_queue'.");
+            }
+
+            EditorUtility.SetDirty(material);
+            AssetDatabase.SaveAssetIfDirty(material);
+
+            return new JObject
+            {
+                ["path"] = AssetDatabase.GetAssetPath(material),
+                ["changed"] = changes,
+            };
+        }
+
+        private static string ApplyProperty(Material material, string property, JToken value)
+        {
+            var index = material.shader.FindPropertyIndex(property);
+            var type = index >= 0 ? material.shader.GetPropertyType(index) : ShaderPropertyType.Float;
+
+            switch (type)
+            {
+                case ShaderPropertyType.Color:
+                    var c = ReadVector4(value, "value");
+                    material.SetColor(property, new Color(c.x, c.y, c.z, c.w));
+                    return c.ToString();
+
+                case ShaderPropertyType.Vector:
+                    var v = ReadVector4(value, "value");
+                    material.SetVector(property, v);
+                    return v.ToString();
+
+                case ShaderPropertyType.Int:
+                    material.SetInteger(property, value.Value<int>());
+                    return value.ToString();
+
+                case ShaderPropertyType.Texture:
+                    var texturePath = value.ToString();
+                    var texture = AssetDatabase.LoadAssetAtPath<Texture>(texturePath);
+
+                    if (texture == null)
+                    {
+                        throw new McpToolException("not_found", $"No texture at '{texturePath}'.");
+                    }
+
+                    material.SetTexture(property, texture);
+                    return texturePath;
+
+                default:
+                    material.SetFloat(property, value.Value<float>());
+                    return value.ToString();
+            }
+        }
+
+        private static Vector4 ReadVector4(JToken token, string argumentName)
+        {
+            if (token is JObject o)
+            {
+                float Axis(params string[] keys)
+                {
+                    foreach (var key in keys)
+                    {
+                        if (o[key] != null && o[key].Type != JTokenType.Null)
+                        {
+                            return o[key].Value<float>();
+                        }
+                    }
+
+                    return 0f;
+                }
+
+                return new Vector4(Axis("x", "r"), Axis("y", "g"), Axis("z", "b"), Axis("w", "a"));
+            }
+
+            if (token is JArray a && a.Count >= 3)
+            {
+                return new Vector4(
+                    a[0].Value<float>(), a[1].Value<float>(), a[2].Value<float>(),
+                    a.Count > 3 ? a[3].Value<float>() : 1f);
+            }
+
+            throw new McpToolException(
+                "invalid_params",
+                $"'{argumentName}' must be {{x,y,z,w}}, {{r,g,b,a}} or an array for this property type.");
+        }
+
+        private static Shader RequireShader(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", "'path' or 'name' is required.");
+            }
+
+            var shader = AssetDatabase.LoadAssetAtPath<Shader>(path.Replace('\\', '/'));
+
+            if (shader == null)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"No shader at '{path}'. asset_find with type 'Shader' will list them.");
+            }
+
+            return shader;
+        }
+
+        private static Shader RequireShaderByName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new McpToolException("invalid_params", "'path' or 'name' is required.");
+            }
+
+            var shader = Shader.Find(name);
+
+            if (shader == null)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"Shader.Find could not resolve '{name}'. The name is the one in the Shader " +
+                    "declaration, not the file name.");
+            }
+
+            return shader;
+        }
+
+        private static Material RequireMaterial(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new McpToolException("invalid_params", "'path' is required.");
+            }
+
+            var material = AssetDatabase.LoadAssetAtPath<Material>(path.Replace('\\', '/'));
+
+            if (material == null)
+            {
+                throw new McpToolException(
+                    "not_found",
+                    $"No material at '{path}'. asset_find with type 'Material' will list them.");
+            }
+
+            return material;
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ShaderTools.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ShaderTools.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f57b5af0e0f3134ba23f38de1ee5411

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "A package that provides integration with the Model Context Protocol (MCP) for Unity.",

--- a/unity-mcp-ts/CHANGELOG.md
+++ b/unity-mcp-ts/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [3.2.0] - 2026-07-28
+
+Released in step with the Unity package, which went from 23 tools to 57. No
+change was needed here: this server forwards whatever the Editor publishes at
+`GET /tools`. Thirty-four new tools appeared through it without a line of
+TypeScript, which is the property the v3 architecture exists to have.
+
+### Changed
+- The bundled skill covers the authoring, rendering and inspection tools, and
+  the two things about them that are not obvious: a path from
+  `scene_browse_hierarchy` is the identifier every editing tool takes, and a
+  scene edit made during Play Mode is reverted when it stops.
+
 ## [3.1.0] - 2026-07-28
 
 Released to keep the version in step with the Unity package, which gained `test_run` and

--- a/unity-mcp-ts/package.json
+++ b/unity-mcp-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiranui_isuzu/unity-mcp",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "main": "build/index.js",
   "type": "module",
   "bin": {

--- a/unity-mcp-ts/skills/isuzu-unity-mcp/SKILL.md
+++ b/unity-mcp-ts/skills/isuzu-unity-mcp/SKILL.md
@@ -95,6 +95,39 @@ cannot be unloaded, so a long session of one-off snippets grows the domain until
 | `compile_request` | Trigger a recompile (`AssetDatabase.Refresh` alone does not) |
 | `test_run --mode edit --assembly MyGame.Tests` | Start a test run; returns immediately |
 | `test_results` | Counts and failures; **answers while the run holds the main thread** |
+
+### Authoring — every one of these is a single undo step
+
+| Tool | Purpose |
+|---|---|
+| `gameobject_create --primitive Cube --name Enemy --parent_path /Root` | Create; returns the `path` to address it by |
+| `gameobject_delete` / `gameobject_duplicate` / `gameobject_reparent` | Undoable, so no confirmation is asked for |
+| `gameobject_set_transform --object_path /Root/Enemy --json '{"position":{"y":2}}'` | Only the axes given are changed |
+| `gameobject_add_component --component_type Rigidbody` / `gameobject_remove_component` | Returns the component list |
+| `asset_find --type Material --folder Assets/Art --limit 20` | Then `asset_info`, `asset_move`, `asset_delete` (to the OS trash) |
+| `asset_create_folder --path Assets/Art/Materials` | Creates parents too; calling it twice is not an error |
+| `scene_list` / `scene_open` / `scene_save` / `scene_create` | `scene_open` refuses over unsaved changes |
+| `prefab_create` / `prefab_instantiate` / `prefab_apply` | `prefab_apply` is not undoable and changes every instance |
+| `build_settings` then `build_player --output_path C:/out/Game.exe` | A cold build returns a job id; poll `jobs <id>` |
+
+### Rendering and shader debugging
+
+| Tool | Purpose |
+|---|---|
+| `shader_errors` | Compilation errors. **A broken shader renders magenta and never says so** — ask after every shader edit |
+| `shader_info` / `material_read` / `material_set` | What a frame is drawn from, as opposed to the shader's defaults |
+| `render_pipeline_info` | The pipeline actually in force. **The quality level overrides graphics settings** |
+| `render_camera_info` | View, projection and GPU projection matrices, for checking a value against a CPU replica |
+| `render_compare --before a.png --after b.png` | Differences as numbers |
+| `reflect_read --path "MyPipeline.Manager/ByCamera[0]/levels[2]"` | Live private state without writing a snippet |
+| `gpu_readback --path "MyPipeline.Manager/pool" --format uint` | **`allZero` answers "did the pass write anything"** in one line |
+
+### Two things that will cost you an afternoon otherwise
+
+- **The `path` these tools take is the one `scene_browse_hierarchy` returns.** It resolves
+  inactive objects, and carries an index only when a sibling name repeats: `/Canvas/Button[1]/Text`.
+- **A scene edit during Play Mode succeeds and is reverted when Play Mode stops.** The response
+  carries `playModeWarning` when that applies. Asset edits made at the same moment do survive.
 | `scene_browse_hierarchy --name Player --limit 20` | Hierarchy; also filters `component`, `tag`, `active_only`, `max_depth` |
 | `inspect_list --game_object_path Player --component_type Transform` | Discover property paths |
 | `inspect_read --game_object_path Player --component_type Transform --property_path m_LocalPosition` | Read one property |
@@ -133,6 +166,18 @@ isuzu-unity-mcp call test_results            # poll; status goes running -> comp
 whole duration. During that window `test_results` is the only tool that answers — poll it
 rather than retrying `test_run`. A `status` of `interrupted` means a domain reload happened
 mid-run and the outcome was lost; start the run again.
+
+### Prove a rendering change did something
+
+```bash
+isuzu-unity-mcp call capture_screenshot --view game --save_path /tmp/before.png
+# toggle the thing under test
+isuzu-unity-mcp call render_compare --before /tmp/before.png --after /tmp/after.png
+```
+
+Compare rather than look. Screenshot colours are post-tonemap, so absolute values do not settle
+an argument; changed-pixel counts and where they are do. Passing `save_path` keeps both images
+out of the conversation entirely.
 
 ### Save a screenshot to a file
 


### PR DESCRIPTION
Thirty-four tools, 23 to 57. Until now the only way to change anything was `execute_code`, which is not on the undo stack, cannot declare its idempotency, and costs a round trip whenever a type name is guessed wrong.

The rendering tools were not chosen from what looked useful. They come from the IsuzuRP notes — a VSM port whose hardest bug took three layers to reach — and from what that campaign did over and over: read a GPU buffer back, read live private state off a manager, check a counter, diff two frames.

## Added

**Authoring** — 21 tools across GameObjects, assets, scenes and prefabs. Every mutation is on the undo stack, so one call is one Ctrl+Z.

**Builds** — `build_settings`, `build_player`, `build_switch_target`. Unity Hub is deliberately not wrapped; an uninstalled target says so and gives the Hub CLI command.

**Rendering and shaders** — `render_compare` reports how two captures differ in numbers rather than pictures. `render_pipeline_info` reports both the graphics-settings pipeline and the quality-level one, because the second overrides the first. `render_camera_info` exposes the view, projection and GPU projection matrices. `shader_errors` replaces the 501 stub that stood in for `/hlsl/errors`.

**Live state** — `reflect_read` reads private members by path; `gpu_readback` reports a buffer's range, mean, zero count and histogram rather than its contents.

`capture_screenshot` takes `save_path`, so a pixel diff never puts two images in the transcript. `scene_browse_hierarchy` emits `path`, the identifier every editing tool takes.

## Fixed — all three shipping since 3.0.0

**One tool call is one undo step.** `ToolInvoker` captured the undo group without incrementing first, so every call in a session shared a group and each collapse merged everything recorded since. One Ctrl+Z reversed the whole conversation. Invisible to any test that made a single call.

**Editor window captures were upside down.** Every Inspector, Hierarchy, Project and Console screenshot came back mirrored top to bottom. The DIB was requested top-down while `LoadRawTextureData` expects bottom-up.

**`render_compare` leaked a texture per failed call** when the second image was missing, and reported a mismatched pair as `tool_failed` because it read the sizes after destroying them.

## Play Mode

A scene edit during Play Mode succeeds, reports truthfully, and is reverted on exit — while an asset edit made at the same moment survives, and nothing distinguished them. Scene-mutating tools now carry a `playModeWarning`. Not a refusal: poking a running scene is legitimate, and a sentence prevents the mistake as well as a block would.

## Verification

| | |
|---|---|
| EditMode | 163/163 (was 94) |
| TypeScript | tsc, lint, 174 tests, build |
| Live against a running Editor | 143 checks across five suites |
| `build_player` | built a real player: 672 KB exe, cold build as a job, incremental inline |
| Tools | 57, no discovery errors |

The new tests are shaped around repetition and boundaries, because every defect above was correct once and wrong afterwards. They were checked by putting two of the bugs back: exactly four fail, and nothing else.

CI gains a check that every declared tool appears in both READMEs. v2 shipped a README listing seven tools that did not exist.