### PR TITLE
Fix Unity 2022.3 compilation by guarding the static batching query

### DIFF
--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
@@ -193,7 +193,11 @@ namespace UnityMCP.Editor.Tools
                 ["shadowResolution"] = QualitySettings.shadowResolution.ToString(),
                 ["shadowDistance"] = QualitySettings.shadowDistance,
                 ["activeBuildTarget"] = EditorUserBuildSettings.activeBuildTarget.ToString(),
+#if UNITY_2023_1_OR_NEWER
                 ["batchingStatic"] = PlayerSettings.GetStaticBatchingForPlatform(EditorUserBuildSettings.activeBuildTarget),
+#else
+                ["batchingStatic"] = JValue.CreateNull(),
+#endif
             };
         }
 


### PR DESCRIPTION
`PlayerSettings.GetStaticBatchingForPlatform` was added in Unity 2023.1, but
`RenderTools.PipelineInfo()` calls it unconditionally. This prevents the package
from compiling on Unity 2022.3 even though the package manifest and README list
Unity 2022.3 as supported.

Fixes #20.

## Failure

The package failed to compile with:

```text
Library\PackageCache\jp.shiranui-isuzu.unity-mcp@baab831e74\Editor\Tools\RenderTools.cs(196,53):
error CS0117: 'PlayerSettings' does not contain a definition for 'GetStaticBatchingForPlatform'
```

Because the Editor assembly did not compile, the UnityMCP server never started
and `isuzu-unity-mcp projects` could not discover the project.

Unity 2022.3 has the internal `GetBatchingForPlatform` API, but the public
`GetStaticBatchingForPlatform` wrapper is only available from Unity 2023.1:

- Unity 2022.3 reference source:
  https://github.com/Unity-Technologies/UnityCsReference/blob/2022.3/Editor/Mono/PlayerSettings.bindings.cs
- Unity 2023.1 release notes:
  https://unity.com/releases/editor/beta/2023.1.0b13

## Fix

Guard the API call with `UNITY_2023_1_OR_NEWER`.

On Unity 2023.1 and newer, `batchingStatic` continues to report the current
boolean value. On Unity 2022.3, where the public API is unavailable, it reports
JSON `null`.

This keeps the change limited to the unsupported query and does not otherwise
change `render_pipeline_info` or the UnityMCP server.

## Prior reports and implementations

I reproduced the same issue reported in #20:

- https://github.com/isuzu-shiranui/UnityMCP/issues/20

After reproducing it, I also checked the repository's forks and found an
independent implementation using the same version guard:

- https://github.com/slix/UnityMCP/commit/4c0127084134f833427be7dcfb2ac3157c21e0a7

That implementation was used as a reference for keeping this fix minimal.

## Verification

Environment:

- Windows 11
- Unity 2022.3.22f1
- VRChat SDK - Avatars 3.10.4
- VRChat SDK - Base 3.10.4
- UnityMCP 3.3.0
- Node.js 26.8.1
- PowerShell 7.6.5
- Project installed through a UPM Git URL

Verified on a live VRChat avatar project:

- The package compiles with zero Console errors.
- The UnityMCP Editor server starts successfully.
- `isuzu-unity-mcp projects` discovers the Unity 2022.3 project.
- `isuzu-unity-mcp health` reports the server as `running`.
- `render_pipeline_info` succeeds and returns `"batchingStatic": null`.
- Read-only tools including `scene_list`, `scene_browse_hierarchy`,
  `inspect_list`, `project_packages`, `project_assemblies`, `asset_find`,
  `asset_info`, and `material_read` return project data successfully.

The change consists of four added lines in `RenderTools.cs`.

## AI-assisted development note

Codex was used as an assistive tool while investigating the issue and editing
the code. The final code and diff were reviewed by a human before submitting
this pull request.
