### PR TITLE
3.3.1: Unity 2022.3 compiles again, Unity 6.5 ids reach the model intact

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,7 +1,7 @@
 # Unity MCP Integration Framework
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-3.2.0-brightgreen)
+![Version](https://img.shields.io/badge/version-3.3.1-brightgreen)
 ![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
 ![.NET](https://img.shields.io/badge/.NET-C%23_9.0-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)
@@ -12,11 +12,11 @@ Opens the Unity Editor to AI agents over the Model Context Protocol, and to peop
 
 ## What's new in v3
 
-- **Tools are defined once, in the Editor.** Put `[McpTool]` on a static C# method and its JSON Schema is derived from the signature and published at `GET /tools`. There is no tool definition on the TypeScript side.
-- **The CLI does not need MCP.** `isuzu-unity-mcp` reads the descriptor file the Editor publishes and connects directly, so reaching Unity from a shell no longer requires an MCP client to be running.
-- **It answers while the Editor is busy.** Tools declaring `MainThread = false`, plus `/health`, `/jobs` and `/tools`, are served from a worker thread — which is exactly when you want to know what the Editor is doing.
-- **Slow work becomes a job.** A call that does not finish in a few seconds returns a job id rather than a timeout, so nothing keeps running behind a failure you might retry.
-- **Authenticated.** Every request needs a bearer token; binding to loopback was never access control.
+- **Tools are defined once, in the Editor.** Put `[McpTool]` on a static C# method. Its JSON Schema is derived from the signature and published at `GET /tools`. There is no tool definition on the TypeScript side.
+- **The CLI does not need MCP.** `isuzu-unity-mcp` reads the descriptor file the Editor publishes and connects directly. No MCP client needs to be running to reach Unity from a shell.
+- **It answers while the Editor is busy.** Tools declaring `MainThread = false`, plus `/health`, `/jobs` and `/tools`, are served from a worker thread. They keep answering while the main thread is blocked.
+- **Slow work becomes a job.** A call that does not finish in a few seconds returns a job id instead of a timeout. Poll the job id for the result instead of repeating the call.
+- **Authenticated.** Every request needs a bearer token. Binding to loopback is not access control.
 
 ## Requirements
 
@@ -45,8 +45,8 @@ npm link          # if you want the isuzu-unity-mcp command
 isuzu-unity-mcp setup   # register with your MCP client and install the Claude Code skill
 ```
 
-`setup` only updates MCP client configs that already exist, rather than creating one for a
-client you do not use, and leaves every other server and key in those files untouched.
+`setup` updates only MCP client configs that already exist. It does not create a config for a
+client you do not use. Other servers and keys in those files are left untouched.
 
 ```bash
 isuzu-unity-mcp doctor      # what is installed, where, and what is stale
@@ -76,7 +76,7 @@ isuzu-unity-mcp tools      # what this Editor publishes
 }
 ```
 
-The Editor does not have to be running first. Until one appears the server answers `tools/list` from its cached catalog, then sends `tools/list_changed`.
+The Editor does not have to be running first. Until one appears, the server answers `tools/list` from its cached catalog. When an Editor appears, the server sends `tools/list_changed`.
 
 ### CLI
 
@@ -92,8 +92,8 @@ isuzu-unity-mcp call execute_code --file snippet.cs
 isuzu-unity-mcp call play_mode_status --project MyGame
 ```
 
-**Inside a project, `--project` is unnecessary.** With several Editors open, a working
-directory that sits inside exactly one of them selects that one.
+**Inside a project, `--project` is unnecessary.** With several Editors open, the CLI selects
+the project whose directory contains the working directory.
 
 ```bash
 cd "H:/Unity Projects/MyGame/Assets/Scripts"
@@ -101,14 +101,14 @@ isuzu-unity-mcp call play_mode_status
 # [using MyGame — the project this directory belongs to]
 ```
 
-`isuzu-unity-mcp projects` marks the reachable one with `containsWorkingDirectory`. Run from
-outside every project and it names the candidates and stops, rather than guessing. The MCP
-server applies the same rule, so opening Claude Code in a Unity project removes the need for
-`target`.
+`isuzu-unity-mcp projects` marks that project with `containsWorkingDirectory`. When run from
+outside every project, the CLI lists the candidates and stops. It does not guess. The MCP
+server applies the same rule, so `target` is not needed when Claude Code is opened inside a
+Unity project.
 
-Errors go to stderr with a non-zero exit code, so it composes in scripts.
+Errors go to stderr with a non-zero exit code, so the CLI can be used in scripts.
 
-> **Why `--file`**: passing a C# snippet through both a shell and a JSON encoder loses the backslashes in its string literals. The result is a compile error inside generated source the caller never sees, which is close to undiagnosable. Reading from a file goes through neither.
+> **Why `--file`**: passing a C# snippet through both a shell and a JSON encoder loses the backslashes in its string literals. The result is a compile error inside generated source that the caller never sees. Reading from a file avoids both layers.
 
 ## Architecture
 
@@ -134,7 +134,7 @@ MCP client (Claude)                        terminal / scripts
 
 `ToolCatalog` collects `[McpTool]` static methods by reflection and derives each JSON Schema from the signature. `ToolInvoker` binds JSON arguments to typed parameters and applies the confirm/dry-run gate and Undo grouping the attribute declares.
 
-`McpMainThreadDispatcher` marshals work from worker threads onto the Editor main thread. It holds the queue lock only to dequeue and runs outside it, so one slow call cannot stall every other request, and a job that has not started can be cancelled with certainty.
+`McpMainThreadDispatcher` marshals work from worker threads onto the Editor main thread. It holds the queue lock only while dequeuing and runs the work outside the lock. One slow call therefore cannot stall other requests, and a job that has not started can be cancelled reliably.
 
 ### MCP server (TypeScript)
 
@@ -142,7 +142,7 @@ MCP client (Claude)                        terminal / scripts
 
 ## Built-in tools
 
-### Published by the Editor (57)
+### Published by the Editor (68)
 
 **Looking**
 
@@ -165,7 +165,7 @@ MCP client (Claude)                        terminal / scripts
 | `project_packages` | safe | UPM packages |
 | `capture_screenshot` | safe | Game or Scene view, or an Editor panel. `save_path` writes it to disk |
 
-**Authoring** — every mutation collapses into one undo step.
+**Authoring**. Every mutation is a single undo step.
 
 | Tool | Idempotency | Purpose |
 |---|---|---|
@@ -209,7 +209,7 @@ MCP client (Claude)                        terminal / scripts
 | `material_read` | safe | A material's **current** values, keywords and render queue |
 | `material_set` | unsafe | Set a property, keyword or render queue |
 
-**Timeline (video / live)** — appear only when `com.unity.timeline` is present.
+**Timeline (video / live)**. These tools appear only when `com.unity.timeline` is present.
 
 | Tool | Idempotency | Purpose |
 |---|---|---|
@@ -217,30 +217,29 @@ MCP client (Claude)                        terminal / scripts
 | `timeline_evaluate` | unsafe | Evaluate a director at a time or frame, without Play mode. Pair with `capture_screenshot` to check one frame |
 | `timeline_edit_clip` | unsafe | One clip's start, length, name, ease, blend and speed. **Reports the values as they landed**, listing anything the clip type discarded in `ignored` |
 | `timeline_shift_clips` | unsafe | **Ripple edit**: move everything at or after a time together. Moves nothing at all if the shift would cross zero |
-| `timeline_set_track` | unsafe | Mute, lock, rename, or bind a track. **Resolves the component the track's type wants** — an Animator for an animation track |
+| `timeline_set_track` | unsafe | Mute, lock, rename, or bind a track. **Resolves the component the track's type wants**, for example an Animator for an animation track |
 | `timeline_delete` | unsafe | Delete a track or a clip; a group takes its children. Undoable, so it does not ask for confirmation |
 | `timeline_create` | unsafe | Create a Timeline asset, optionally with a director. **The only entry point that makes track creation safe** |
 | `timeline_create_track` | unsafe | Add a track (activation, animation, audio, control, group, playable, signal), optionally inside a group and bound in the same call |
 | `timeline_create_clip` | unsafe | Add a clip. `control_source` **wires a Control clip's nesting in one call**; `animation_clip` sets the AnimationClip to play |
 
-The editing tools report the **effective** value read back after the write, not the requested one:
-Timeline's setters discard values a clip type does not support — the speed of an Activation clip,
-for instance — without raising anything, so echoing the request would leave the caller believing a
-change that never happened. The creation tools refuse before acting if the timeline is not yet an
-asset, because Timeline would then build the track in memory only, with no public API to persist it
-afterwards.
+The editing tools report the value read back after the write, not the requested one.
+Timeline's setters discard values a clip type does not support, such as the speed of an Activation
+clip, and raise no error. Echoing the request would make the caller believe a change that never
+happened. The creation tools refuse to act if the timeline is not yet an asset. Timeline would
+otherwise build the track in memory only, and there is no public API to persist it afterwards.
 
-**Recorder (rendering out)** — appear only when both `com.unity.recorder` and `com.unity.timeline` are present.
+**Recorder (rendering out)**. These tools appear only when both `com.unity.recorder` and `com.unity.timeline` are present.
 
 | Tool | Idempotency | Purpose |
 |---|---|---|
 | `recorder_add_track` | unsafe | Add a Recorder track to a Timeline, so **playing the director records it**. mp4 / webm / mov and png / jpeg / exr, capturing the game view, a camera or a RenderTexture, at a chosen resolution |
 | `recorder_list` | safe | What a Timeline will record, and **where it will be written** |
 
-Recording runs as a track on the Timeline rather than through the Recorder API directly: the
-frame rate then comes from the Timeline itself, so the recording cannot drift from the animation,
-and the setup is less exposed to the Recorder API's version drift. Omit `output_path` to write to
-a `Recording` folder beside `Assets`, named after the Timeline.
+Recording runs as a track on the Timeline, not through the Recorder API directly. The frame rate
+comes from the Timeline itself, so the recording cannot drift from the animation. The setup also
+depends less on changes to the Recorder API between versions. Omit `output_path` to write to a
+`Recording` folder beside `Assets`, named after the Timeline.
 
 **Live state and GPU**
 
@@ -261,23 +260,23 @@ a `Recording` folder beside `Assets`, named after the Timeline.
 
 Editor panel capture (`inspector`, `hierarchy`, `project`, `console`, `window:<title>`) is Windows-only; `game` and `scene` work everywhere.
 
-`test_run` and `test_results` appear only when `com.unity.test-framework` is present, which it is by default. They live in their own assembly constrained to `UNITY_INCLUDE_TESTS`, so a project without the framework loses those two tools rather than failing to compile the package.
+`test_run` and `test_results` appear only when `com.unity.test-framework` is present. It is present by default. They live in their own assembly constrained to `UNITY_INCLUDE_TESTS`. A project without the framework loses those two tools, and the package still compiles.
 
 ### Things that will bite otherwise
 
 - **The `path` an editing tool takes is the one `scene_browse_hierarchy` returns.** It resolves
   inactive objects, and carries an index only where a sibling name repeats: `/Canvas/Button[1]/Text`.
 - **A scene edit made during Play Mode looks like it worked and is reverted when Play Mode stops.**
-  Those responses carry a `playModeWarning`. Asset edits made at the same moment do survive, so
-  they do not.
-- **Deletion is recoverable rather than gated.** Assets go to the OS trash and GameObjects go
-  through Undo, so neither asks for confirmation. Opening or replacing a scene over unsaved
-  changes *is* refused, because that is the one edit no undo stack can return.
+  Those responses carry a `playModeWarning`. Asset edits made during Play Mode survive, so they
+  carry no warning.
+- **Deletion is recoverable, so it asks for no confirmation.** Assets go to the OS trash and
+  GameObjects go through Undo. Opening or replacing a scene over unsaved changes is refused,
+  because Undo cannot restore unsaved changes.
 - **`execute_code` is not on the undo stack.** Use the authoring tools for authoring.
 
 ### Provided by the MCP server (3)
 
-`unity_list_clients`, `unity_set_active_client`, `unity_get_active_client` — choosing between Editors. No single Editor can answer that, which is why these stay here.
+`unity_list_clients`, `unity_set_active_client` and `unity_get_active_client` choose between Editors. No single Editor can answer that question, so these tools live in the server.
 
 ### Prompts
 
@@ -311,20 +310,20 @@ internal static class MyTools
 }
 ```
 
-It appears in `/tools` and is callable from both MCP clients and the CLI. The schema comes from the signature, so there is only one place to write it.
+The tool appears in `/tools` and can be called from both MCP clients and the CLI. The schema comes from the signature, so it is written in one place only.
 
 `[McpTool]` properties:
 
 | Property | Default | Meaning |
 |---|---|---|
 | `Idempotency` | `Unsafe` | Whether the call may be retried automatically after a connection failure. Read-only tools should say `Safe` |
-| `MainThread` | `true` | Whether the Editor main thread is required. `false` keeps the tool answerable while the Editor is busy — only for tools touching no Unity API |
+| `MainThread` | `true` | Whether the Editor main thread is required. `false` keeps the tool answerable while the Editor is busy. Use it only for tools that touch no Unity API |
 | `Destructive` | `false` | When true the call refuses without `confirm: true` and supports `dry_run` |
 | `UndoGroup` | `null` | When set, the whole call collapses into a single Undo step |
 
 Tool names must match `^[a-z][a-z0-9_]{0,63}$`; MCP tool names cannot contain dots.
 
-**The description is the model's only cue for reaching for a tool.** Say when to use it, not just what it does.
+**The description is the only cue the model has for choosing a tool.** Say when to use it, not just what it does.
 
 ## Configuration
 
@@ -366,48 +365,47 @@ isuzu-unity-mcp call test_results --include_passed true --limit 200
 ```
 
 **A test run holds the main thread for its whole duration, so no other tool answers during it.**
-`test_results` is declared `MainThread = false` and reports counts and failures anyway. `test_run`
-returns as soon as the run is queued; it does not wait for the outcome.
+`test_results` is declared `MainThread = false`, so it still reports counts and failures. `test_run`
+returns as soon as the run is queued. It does not wait for the outcome.
 
 Running the package's tests needs `"testables": ["jp.shiranui-isuzu.unity-mcp"]` in the
 project's `Packages/manifest.json`.
 
 ## Troubleshooting
 
-**`isuzu-unity-mcp projects` finds nothing** — check an Editor has a project open and its server started. Descriptors live under `%LOCALAPPDATA%\UnityMCP\instances\`, or `~/.local/share` / `~/Library/Application Support` on macOS and Linux.
+**`isuzu-unity-mcp projects` finds nothing.** Check that an Editor has a project open and that its server started. Descriptors live under `%LOCALAPPDATA%\UnityMCP\instances\`, or `~/.local/share` / `~/Library/Application Support` on macOS and Linux.
 
-**401 responses** — the token is in the descriptor file. The CLI and MCP server read it for you; curl needs `Authorization: Bearer <token>`. Going through `isuzu-unity-mcp`, or the MCP server's `/proxy`, avoids handling it.
+**401 responses.** The token is in the descriptor file. The CLI and MCP server read it for you. curl needs `Authorization: Bearer <token>`. Requests through `isuzu-unity-mcp` or the MCP server's `/proxy` do not need the token.
 
-**The console reports nothing but you expect output** — `console_read_logs` reflects what the Editor console currently holds. When you suspect it has dropped something, read the file directly with `editor_log_tail`, which works even while the Editor is busy.
+**The console reports nothing but you expect output.** `console_read_logs` returns what the Editor console currently holds. If you suspect an entry was dropped, read the log file directly with `editor_log_tail`. It works even while the Editor is busy.
 
-**A script edit does not take effect** — `AssetDatabase.Refresh()` does not reliably trigger a compile. Use `compile_request`, then check `succeeded` with `compile_status`. After a failed compile the Editor keeps running the previous assembly with `isCompiling` back to false, so silence does not mean success.
+**A script edit does not take effect.** `AssetDatabase.Refresh()` does not reliably trigger a compile. Use `compile_request`, then check `succeeded` with `compile_status`. After a failed compile, the Editor keeps running the previous assembly and sets `isCompiling` back to false. Silence does not mean success.
 
-**A call returned a job id** — work slower than `syncWaitMs` (3 s by default) becomes a job. Collect it with `isuzu-unity-mcp jobs <id>`. **Do not repeat the call**: the work is still running.
+**A call returned a job id.** Work slower than `syncWaitMs` (3 s by default) becomes a job. Collect the result with `isuzu-unity-mcp jobs <id>`. **Do not repeat the call.** The work is still running.
 
 ## Security
 
 - The server binds `127.0.0.1` only and **requires a bearer token on every request**.
-- No CORS headers are sent. v2 returned `Access-Control-Allow-Origin: *`, which let any web page the user had open POST to `/execute_code` and run arbitrary C# in their Editor.
+- No CORS headers are sent. A web page open in the user's browser therefore cannot POST to the server and run C# in the Editor.
 - **Treat the descriptor file as a credential.** Anything that can read it can run code in the Editor.
 - `execute_code` and `menu_execute` run with full Editor privileges. Do not feed them untrusted code.
 
 ### It cannot ship in a build
 
 This package runs an HTTP server that compiles and executes arbitrary C#. In the Editor that
-is the point; in a shipped game it would be a remote code execution hole. Two independent
-guarantees keep it out:
+is its purpose. In a shipped game it would be a remote code execution hole. Two independent
+guarantees keep it out of builds:
 
 1. The assembly definition is `"includePlatforms": ["Editor"]`, so it is never compiled into
    a player build.
 2. Every source file and binary lives under an `Editor/` folder, which Unity excludes from
    builds regardless of importer settings.
 
-**Nothing reaches a player, Development Build included** — there is no runtime assembly at
+**Nothing reaches a player, Development Build included.** There is no runtime assembly at
 all. If runtime functionality is ever added, gate it explicitly on `DEVELOPMENT_BUILD`.
 
-This is a checked property rather than a remembered convention: CI asserts both on every
-change, and both were verified to fail the build when violated — one by adding a script under
-`Runtime/`, the other by emptying `includePlatforms`.
+CI asserts both guarantees on every change. Each check fails the build when violated: the first
+when a script is added under `Runtime/`, the second when `includePlatforms` is emptied.
 
 ## What this puts on your machine
 
@@ -428,13 +426,13 @@ isuzu-unity-mcp uninstall         # lists what would go
 isuzu-unity-mcp uninstall --yes   # removes it
 ```
 
-`uninstall` takes only the `isuzu-unity-mcp` entry out of your MCP client configs and leaves every
-other server alone. It refuses while an Editor is running, since that Editor would republish
-its descriptor moments later. The Unity package itself is removed through the Package Manager.
+`uninstall` removes only the `isuzu-unity-mcp` entry from your MCP client configs. Other servers
+are left alone. It refuses to run while an Editor is running, because that Editor would republish
+its descriptor right after. The Unity package itself is removed through the Package Manager.
 
 ## Migrating from v2
 
-This release is deliberately breaking.
+This release contains breaking changes.
 
 | v2 | v3 |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unity MCP 統合フレームワーク
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-3.2.0-brightgreen)
+![Version](https://img.shields.io/badge/version-3.3.1-brightgreen)
 ![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
 ![.NET](https://img.shields.io/badge/.NET-C%23_9.0-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)
@@ -14,13 +14,14 @@ Unity Editor を Model Context Protocol (MCP) 経由で AI エージェントに
 
 - **ツール定義は Editor 側の1箇所だけ** — C# の static メソッドに `[McpTool]` を付けると、シグネチャから JSON Schema が生成され `GET /tools` で配信されます。TypeScript 側にツール定義はありません。
 - **CLI が MCP から独立** — `isuzu-unity-mcp` コマンドは Editor が公開する descriptor ファイルを読んで直接接続します。MCP クライアントを起動しておく必要はありません。
-- **メインスレッドが詰まっても応答する** — `MainThread = false` を宣言したツールと `/health` `/jobs` `/tools` はワーカースレッドで応答します。Editor が「Hold on」で固まっている最中こそ状態を知りたいので。
+- **メインスレッドが詰まっても応答する** — `MainThread = false` を宣言したツールと `/health` `/jobs` `/tools` はワーカースレッドで応答します。Editor が「Hold on」で固まっている最中でも状態を確認できます。
 - **遅い処理はジョブになる** — 数秒で終わらない呼び出しは job ID を返します。タイムアウトを返しつつ裏で実行を続ける、ということはありません。
-- **認証必須** — 全リクエストに bearer token が要ります。ローカルバインドはアクセス制御ではありません。
+- **認証必須** — 全リクエストに bearer token が必要です。ローカルアドレスへのバインドだけではアクセス制御になりません。
 
 ## 必要条件
 
-- Unity Editor 2022.3 以降（Unity 6.0 / 6.3 / 6.5 の EditMode で検証。6.5 の EntityId 移行にも対応）
+- Unity Editor 2022.3 以降（2022.3 / 2023.1 / 2023.2 / 6.0 / 6.1 / 6.3 / 6.5 の EditMode で検証しています）
+  - Unity 6.5 以降では `instanceId` が JSON の数値ではなく文字列で返ります。64 ビットの EntityId は JavaScript の数値では正確に表せないためです。引数の `instance_id` は数値と文字列のどちらでも受け付けます。
 - Node.js 18 以降
 - `com.unity.nuget.newtonsoft-json` 3.2.1（依存として自動解決されます）
 
@@ -99,11 +100,11 @@ isuzu-unity-mcp call play_mode_status
 # [using MyGame — the project this directory belongs to]
 ```
 
-`isuzu-unity-mcp projects` の `containsWorkingDirectory` が、いまここから届く Editor を示します。どのプロジェクトの外でもない場所から曖昧なまま実行した場合は、推測せずに候補を挙げて止まります。同じ判定は MCP サーバ側でも働くので、Claude Code をプロジェクトで開いていれば `target` の指定は要りません。
+`isuzu-unity-mcp projects` の `containsWorkingDirectory` が、カレントディレクトリから選ばれる Editor を示します。どのプロジェクトにも属さない場所から実行して候補が複数あるときは、推測せずに候補を表示して停止します。同じ判定は MCP サーバ側でも行われるので、Claude Code をプロジェクト内で開いていれば `target` の指定は不要です。
 
-エラーは stderr に出て終了コードが非ゼロになるので、そのままスクリプトに組み込めます。
+エラーは stderr に出力され、終了コードが 0 以外になるので、そのままスクリプトに組み込めます。
 
-> **`--file` を使う理由**: C# のスニペットをシェルと JSON エンコーダの両方に通すと、文字列リテラル中のバックスラッシュが失われます。結果は「呼び出し側に見えない生成ソース中のコンパイルエラー」になり、原因の特定が非常に困難です。ファイルから読めばそのどちらも経由しません。
+> **`--file` を使う理由**: C# のスニペットをシェルと JSON エンコーダの両方に通すと、文字列リテラル中のバックスラッシュが失われます。その結果、呼び出し側からは見えない生成ソースでコンパイルエラーが起き、原因の特定が難しくなります。ファイルから読めばどちらも経由しません。
 
 ## アーキテクチャ
 
@@ -129,7 +130,7 @@ MCP クライアント (Claude)                  ターミナル / スクリプ�
 
 `ToolCatalog` が `[McpTool]` の付いた static メソッドをリフレクションで収集し、シグネチャから JSON Schema を作ります。`ToolInvoker` が JSON 引数を型付きパラメータに束縛し、`confirm` / `dry_run` ゲートと Undo グルーピングを適用します。
 
-`McpMainThreadDispatcher` がワーカースレッドから Editor メインスレッドへ処理を渡します。キューからの取り出しだけロックし実行はロック外で行うので、遅い処理が他のリクエストの受付を止めません。開始前のジョブは確実に中止できます。
+`McpMainThreadDispatcher` がワーカースレッドから Editor メインスレッドへ処理を渡します。キューからの取り出しだけをロックし、実行はロックの外で行うので、遅い処理が他のリクエストの受付を止めません。開始前のジョブは確実に中止できます。
 
 ### MCP サーバ側 (TypeScript)
 
@@ -137,7 +138,7 @@ MCP クライアント (Claude)                  ターミナル / スクリプ�
 
 ## 組み込みツール
 
-### Editor が公開するもの（57個）
+### Editor が公開するもの（68個）
 
 **診断（見る）**
 
@@ -199,7 +200,7 @@ MCP クライアント (Claude)                  ターミナル / スクリプ�
 | `render_compare` | safe | 2枚のキャプチャの差を**数値で**返す（差分画素数・平均/最大デルタ・矩形・グリッド） |
 | `render_pipeline_info` | safe | 実効 RP、色空間、Graphics API、品質レベル。**Quality 側の RP 上書き**も併記 |
 | `render_camera_info` | safe | カメラと view / projection / **GPU projection** 行列 |
-| `shader_errors` | safe | シェーダーのコンパイルエラー（**黙って magenta になるので聞かないと分からない**） |
+| `shader_errors` | safe | シェーダーのコンパイルエラー。シェーダーはエラーを出さずに magenta 表示になるので、明示的に確認する必要があります |
 | `shader_info` | safe | パス数、プロパティ、キーワード空間、render queue |
 | `material_read` | safe | マテリアルの**現在値**・有効キーワード・render queue |
 | `material_set` | unsafe | プロパティ / キーワード / render queue を変更 |
@@ -231,8 +232,7 @@ MCP クライアント (Claude)                  ターミナル / スクリプ�
 | `recorder_add_track` | unsafe | Timeline に Recorder トラックを追加し、**director を再生するだけで録画**にする。mp4 / webm / mov と png / jpeg / exr、入力は game view / カメラ / RenderTexture、解像度指定可 |
 | `recorder_list` | safe | その Timeline が**何をどこへ書き出すか**（形式・出力先・有効/無効） |
 
-Recorder を直接叩かず Timeline のトラックとして持つのは、**フレームレートが Timeline 側から入る**ため
-（録画とタイムラインがズレない）で、かつ Recorder API のバージョン差の影響を受けにくいからです。
+Recorder を直接操作せず Timeline のトラックとして持つ理由は2つあります。フレームレートが Timeline 側から決まるので録画とタイムラインの時刻が一致すること、そして Recorder API のバージョン差の影響を受けにくいことです。
 `output_path` を省くと `Assets` と同階層の `Recording` フォルダに Timeline 名で書き出します。
 
 **内部状態・GPU**
@@ -249,25 +249,25 @@ Recorder を直接叩かず Timeline のトラックとして持つのは、**�
 | ツール | 冪等性 | 用途 |
 |---|---|---|
 | `build_settings` | safe | 実効ビルドターゲット、ビルドに入るシーン、モジュールの有無 |
-| `build_player` | unsafe | プレイヤービルド。コールドは job、増分はインラインで返る |
+| `build_player` | unsafe | プレイヤービルド。初回ビルドは job になり、増分ビルドはその場で結果を返します |
 | `build_switch_target` | unsafe | ビルドターゲット切替（再インポートを伴う） |
 
 Editor パネルのキャプチャ（`inspector` / `hierarchy` / `project` / `console` / `window:<title>`）は Windows 限定です。`game` と `scene` は全プラットフォームで動きます。
 
 `test_run` / `test_results` は `com.unity.test-framework` が入っているときだけ現れます（Unity の既定パッケージなので通常は入っています）。専用のアセンブリに分けて `UNITY_INCLUDE_TESTS` で制約しているため、無い環境ではこの2つが一覧に出ないだけで、パッケージ全体は変わらず動きます。
 
-Unity Hub の操作（Editor やモジュールのインストール）は**あえて持ちません**。Hub 自身に CLI があるので、未インストールのビルドターゲットを指定したときに実行すべきコマンドを返します。
+Unity Hub の操作（Editor やモジュールのインストール）は提供しません。Hub 自身に CLI があるので、未インストールのビルドターゲットを指定したときは実行すべき Hub のコマンドを返します。
 
-### 知っておくと事故らないこと
+### 注意点
 
 - **編集系ツールが受け取る `path` は `scene_browse_hierarchy` が返すものです。** 非アクティブなオブジェクトも解決でき、兄弟に同名がいるときだけ `/Canvas/Button[1]/Text` と添字が付きます。
 - **Play Mode 中のシーン編集は、成功したように見えて終了時に破棄されます。** その状況では応答に `playModeWarning` が付きます。アセットの変更は残るので、そちらには付きません。
-- **削除は確認を求めず、戻せるようにしてあります。** アセットは OS のゴミ箱へ、GameObject は Undo 経由です。ただし**未保存シーンへの上書きは拒否します**（これだけは Undo でも戻せないため）。
+- **削除は確認を求めません。その代わり、必ず元に戻せます。** アセットは OS のゴミ箱へ移動し、GameObject は Undo で戻せます。ただし**未保存シーンへの上書きは拒否します**。これだけは Undo でも戻せないためです。
 - **`execute_code` は Undo に乗りません。** オーサリングは専用ツールを使ってください。
 
 ### MCP サーバが提供するもの（3個）
 
-`unity_list_clients` / `unity_set_active_client` / `unity_get_active_client` — 複数 Editor の選択。どの Editor 単体にも答えられない問いなので、ここに残っています。
+`unity_list_clients` / `unity_set_active_client` / `unity_get_active_client` は、複数の Editor から対象を選ぶツールです。1つの Editor だけでは答えられない問いなので、MCP サーバ側に置いています。
 
 ### プロンプト
 
@@ -362,41 +362,41 @@ Unity 側のテストを走らせるには、プロジェクトの `Packages/man
 
 ## トラブルシューティング
 
-**`isuzu-unity-mcp projects` が何も返さない** — Editor がプロジェクトを開いていて、サーバが起動しているか確認してください。descriptor は `%LOCALAPPDATA%\UnityMCP\instances\`（macOS / Linux では `~/.local/share` または `~/Library/Application Support` 配下）に作られます。
+**`isuzu-unity-mcp projects` が何も返さないとき** — Editor がプロジェクトを開いていて、サーバが起動しているか確認してください。descriptor は `%LOCALAPPDATA%\UnityMCP\instances\`（macOS / Linux では `~/.local/share` または `~/Library/Application Support` 配下）に作られます。
 
-**401 が返る** — トークンは descriptor ファイルにあります。CLI と MCP サーバは自動で読みますが、curl で直接叩く場合は `Authorization: Bearer <token>` が要ります。`isuzu-unity-mcp` 経由にするか、MCP サーバの `/proxy` を使えばトークンを意識せずに済みます。
+**401 が返るとき** — トークンは descriptor ファイルにあります。CLI と MCP サーバは自動で読みますが、curl で直接呼ぶ場合は `Authorization: Bearer <token>` ヘッダーが必要です。`isuzu-unity-mcp` 経由にするか、MCP サーバの `/proxy` を使えばトークンを意識せずに済みます。
 
-**ログが無いはずがないのに空** — `console_read_logs` は Editor コンソールの現在の内容を返します。取りこぼしが疑われるときは `editor_log_tail` でログファイルを直接読んでください。こちらは Editor がビジーでも動きます。
+**ログがあるはずなのに空のとき** — `console_read_logs` は Editor コンソールの現在の内容を返します。取りこぼしが疑われるときは `editor_log_tail` でログファイルを直接読んでください。こちらは Editor がビジーでも動きます。
 
-**スクリプトを編集したのに反映されない** — `AssetDatabase.Refresh()` は必ずしも再コンパイルを起こしません。`compile_request` を使い、`compile_status` で `succeeded` を確認してください。コンパイルに失敗すると Editor は直前のアセンブリのまま `isCompiling` を false に戻すので、「静か」＝「成功」ではありません。
+**スクリプトを編集したのに反映されないとき** — `AssetDatabase.Refresh()` は必ずしも再コンパイルを起こしません。`compile_request` を使い、`compile_status` で `succeeded` を確認してください。コンパイルに失敗すると Editor は直前のアセンブリのまま `isCompiling` を false に戻すので、エラーが表示されないことは成功を意味しません。
 
-**呼び出しが job ID を返した** — `syncWaitMs`（既定3秒）を超えた処理はジョブになります。`isuzu-unity-mcp jobs <id>` で結果を取ってください。**同じ呼び出しをやり直さないでください。** 処理はまだ動いています。
+**呼び出しが job ID を返したとき** — `syncWaitMs`（既定3秒）を超えた処理はジョブになります。`isuzu-unity-mcp jobs <id>` で結果を取ってください。**同じ呼び出しをやり直さないでください。** 処理はまだ動いています。
 
 ## セキュリティ
 
 - サーバは `127.0.0.1` のみにバインドし、**全リクエストに bearer token を要求します**。
-- CORS ヘッダは送りません。v2 は `Access-Control-Allow-Origin: *` を返しており、ユーザーが開いている任意の Web ページが `/execute_code` に POST して Editor 内で任意の C# を実行できました。
-- **descriptor ファイルは資格情報として扱ってください。** 読める者は Editor 内でコードを実行できます。
+- CORS ヘッダは送りません。ブラウザで開いた Web ページから Editor の HTTP サーバを呼び出すことはできません。
+- **descriptor ファイルは資格情報として扱ってください。** このファイルを読めれば Editor 内でコードを実行できます。
 - `execute_code` と `menu_execute` は Editor の全権限で動きます。信頼できないコードを流さないでください。
 
 ### ビルドには入りません
 
-このパッケージが任意の C# をコンパイル・実行する HTTP サーバである以上、ビルドに混入すれば遠隔コード実行の穴になります。そうならないことは**2重に保証**されています。
+このパッケージは任意の C# をコンパイル・実行する HTTP サーバなので、ビルドに混入すればリモートコード実行の脆弱性になります。混入しないことは**2重に保証**されています。
 
 1. アセンブリ定義が `"includePlatforms": ["Editor"]` — プレイヤービルドにコンパイルされません
 2. すべてのソースと DLL が `Editor/` 配下 — Unity は importer 設定に関わらずビルドから除外します
 
 **Development Build も含めて、プレイヤーには一切入りません。** ランタイム側のアセンブリ自体が存在しないためです。将来ランタイム機能を足す場合は `DEVELOPMENT_BUILD` で明示的にゲートしてください。
 
-これは規約に頼った約束ではなく、CI が両方を毎回検査します。`Runtime/` にスクリプトを1つ置く、あるいは asmdef の `includePlatforms` を空にする、いずれもビルドが落ちることを確認済みです。
+この2点は CI が毎回検査します。`Runtime/` にスクリプトを1つ置く、あるいは asmdef の `includePlatforms` を空にすると、CI が失敗します。
 
 ## マシン上に置くもの
 
-状態はすべて1つのルート配下にまとまっているので、消すときは1箇所で済みます。
+状態はすべて1つのディレクトリ配下にまとまっているので、削除は1箇所で済みます。
 
 | パス | 中身 |
 |---|---|
-| `%LOCALAPPDATA%\UnityMCP\instances\` | 起動中 Editor の descriptor（ポートとトークン）。終了時に自分で削除し、起動時に pid 死亡分を掃除 |
+| `%LOCALAPPDATA%\UnityMCP\instances\` | 起動中 Editor の descriptor（ポートとトークン）。Editor 終了時に削除され、起動時にプロセスが終了済みのものを削除します |
 | `%LOCALAPPDATA%\UnityMCP\cache\` | ツールカタログのキャッシュ |
 | `~/.claude/skills/isuzu-unity-mcp/` | Claude Code / Codex スキル（`setup` で導入） |
 | MCP クライアント設定の `isuzu-unity-mcp` エントリ | `setup` で追加 |
@@ -408,7 +408,7 @@ isuzu-unity-mcp uninstall         # 消す対象を一覧表示するだけ
 isuzu-unity-mcp uninstall --yes   # 実行
 ```
 
-`uninstall` は MCP クライアント設定から `isuzu-unity-mcp` エントリだけを取り除き、他のサーバや設定には触れません。Editor が起動中だと descriptor をすぐ再作成してしまうので、その場合は実行を拒否して先に閉じるよう促します。Unity パッケージ本体の削除は Package Manager から行ってください。
+`uninstall` は MCP クライアント設定から `isuzu-unity-mcp` エントリだけを取り除き、他のサーバや設定には触れません。Editor が起動中だと descriptor がすぐ再作成されるので、その場合は実行を拒否し、先に Editor を閉じるよう案内します。Unity パッケージ本体の削除は Package Manager から行ってください。
 
 ## v2 からの移行
 
@@ -426,7 +426,7 @@ isuzu-unity-mcp uninstall --yes   # 実行
 | 認証なし | bearer token 必須 |
 | TypeScript でハンドラを書く | C# に `[McpTool]` を書く |
 
-curl ベースの手順書は `isuzu-unity-mcp call` に置き換えるか、MCP サーバの `/proxy/<project>/...` 経由にしてください。後者はトークンを自動で付与します。
+curl を使った手順書は `isuzu-unity-mcp call` に置き換えるか、MCP サーバの `/proxy/<project>/...` 経由にしてください。後者はトークンを自動で付けます。
 
 ## ライセンス
 

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [3.3.1] - 2026-09-03
+
+### Fixed
+- **Unity 2022.3 compiles again.** `PlayerSettings.GetStaticBatchingForPlatform` exists only from
+  2023.1, so `render_pipeline_info` reports `batchingStatic` as null on 2022.3 instead of failing
+  the whole package to compile. Reported in #20, fixed in #21 by @takara2314.
+- **Unity 6.5 instance ids reach the model intact.** A 6.5 EntityId is about 5.7e17, above the
+  2^53 a JSON number survives on its way through JavaScript. Ids were rounded twice: once by the
+  MCP server parsing the Editor's reply, once by the Editor coercing the argument through a
+  double. The rounded id then named nothing, and every id-addressed call on 6.5 failed with
+  `not_found`. On 6.5 and later `instanceId` is now a JSON string, and 64-bit arguments accept a
+  string or an integer without going through a double. Earlier Unity versions are unchanged.
+- The Settings window no longer freezes the Editor when it is open during a domain reload.
+  Styles are created on first draw instead of in `OnActivate`, where `EditorStyles` can still be
+  null.
+- `timeline_inspect` keeps its visited set as 64-bit ids, so a Control track that loops back to
+  its own timeline is still detected on 6.5.
+
+### Verified
+EditMode suite (232 tests) on 2022.3.9f1, 2022.3.22f1, 2023.1.13f1, 2023.2.20f1, 6000.0.35f1,
+6000.1.17f1, 6000.3.19f1, 6000.5.10f1.
+
 ## [3.3.0] - 2026-07-31
 
 ### Added

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/EntityIdCompat.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/EntityIdCompat.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json.Linq;
+
 using UnityEditor;
 
 using UnityObject = UnityEngine.Object;
@@ -15,18 +17,19 @@ namespace UnityMCP.Editor.Core
     /// (the reverse). The same three operations — object to id, id to object, and a serialized
     /// reference's id — therefore have two spellings depending on the Editor. Splitting on
     /// <c>UNITY_6000_5_OR_NEWER</c> here means the ten call sites do not each carry a <c>#if</c>,
-    /// and the wire contract stays put: the value is still called <c>instanceId</c> and is still a
-    /// JSON number.
+    /// and the wire contract stays put: the value is still called <c>instanceId</c>.
     /// <para>
-    /// The wire type is <c>long</c>, not <c>int</c>. A 64-bit EntityId does not fit in an int, and
-    /// truncating it would hand back an id that resolves to the wrong object or to nothing. Real
-    /// ids are small — a scene object's is a negative number in the thousands — so this stays well
-    /// inside the range a JSON number represents exactly.
+    /// In process the id is a <c>long</c>. On the wire it is a JSON number before 6.5 and a JSON
+    /// string from 6.5 on. A 6.5 EntityId packed into a ulong is around 5.7e17, far above the
+    /// 2^53 a JSON number survives on the way through JavaScript: the MCP server and every MCP
+    /// client parse numbers as doubles, so a numeric id would come back with its low bits rounded
+    /// off and name a different object, or none. <see cref="Wire"/> makes that choice once, and
+    /// <c>ToolInvoker</c> accepts either spelling as an argument without going through a double.
     /// </para>
     /// </remarks>
     internal static class EntityIdCompat
     {
-        /// <summary>The wire identifier for an object.</summary>
+        /// <summary>The identifier of an object, as a value.</summary>
         public static long IdOf(UnityObject obj)
         {
 #if UNITY_6000_5_OR_NEWER
@@ -36,7 +39,7 @@ namespace UnityMCP.Editor.Core
 #endif
         }
 
-        /// <summary>The object a wire identifier names, or null.</summary>
+        /// <summary>The object an identifier names, or null.</summary>
         public static UnityObject Find(long id)
         {
 #if UNITY_6000_5_OR_NEWER
@@ -55,5 +58,24 @@ namespace UnityMCP.Editor.Core
             return property.objectReferenceInstanceIDValue;
 #endif
         }
+
+        /// <summary>
+        /// An identifier in the form it is written into a tool result: a JSON string on Unity 6.5
+        /// and later, where it does not fit a JSON number exactly, and a JSON number before that.
+        /// </summary>
+        public static JToken Wire(long id)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return new JValue(id.ToString(System.Globalization.CultureInfo.InvariantCulture));
+#else
+            return new JValue(id);
+#endif
+        }
+
+        /// <summary><see cref="Wire"/> of <see cref="IdOf"/>.</summary>
+        public static JToken WireIdOf(UnityObject obj) => Wire(IdOf(obj));
+
+        /// <summary><see cref="Wire"/> of <see cref="ObjectReferenceId"/>.</summary>
+        public static JToken WireObjectReferenceId(SerializedProperty property) => Wire(ObjectReferenceId(property));
     }
 }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -35,7 +35,7 @@ namespace UnityMCP.Editor.Core
         /// remains only as the answer for an assembly that is not loaded from a package, and CI
         /// checks that it too stays in step.
         /// </remarks>
-        private const string FallbackVersion = "3.3.0";
+        private const string FallbackVersion = "3.3.1";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/ToolCatalog.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/ToolCatalog.cs
@@ -392,10 +392,16 @@ namespace UnityMCP.Editor.Core
                 };
             }
 
+            if (underlying == typeof(long) || underlying == typeof(ulong))
+            {
+                // A 64-bit value does not survive a JSON number through JavaScript, so a string is
+                // an accepted spelling; Unity 6.5 instance ids arrive that way (see EntityIdCompat).
+                return new JObject { ["type"] = new JArray("integer", "string") };
+            }
+
             if (underlying == typeof(byte) || underlying == typeof(sbyte) ||
                 underlying == typeof(short) || underlying == typeof(ushort) ||
-                underlying == typeof(int) || underlying == typeof(uint) ||
-                underlying == typeof(long) || underlying == typeof(ulong))
+                underlying == typeof(int) || underlying == typeof(uint))
             {
                 return new JObject { ["type"] = "integer" };
             }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/ToolInvoker.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/ToolInvoker.cs
@@ -312,6 +312,22 @@ namespace UnityMCP.Editor.Core
 
         private static object CoerceNumber(JToken token, Type targetType)
         {
+            // An integral target never goes through a double. A Unity 6.5 EntityId is about 5.7e17,
+            // above the 2^53 a double holds exactly, and rounding one names a different object.
+            if (IsIntegral(targetType))
+            {
+                if (token.Type == JTokenType.Integer)
+                {
+                    return Convert.ChangeType(token.Value<long>(), targetType, CultureInfo.InvariantCulture);
+                }
+
+                if (token.Type == JTokenType.String &&
+                    long.TryParse(token.Value<string>(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var exact))
+                {
+                    return Convert.ChangeType(exact, targetType, CultureInfo.InvariantCulture);
+                }
+            }
+
             double value;
 
             switch (token.Type)

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/InspectorAccess.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/InspectorAccess.cs
@@ -184,7 +184,7 @@ namespace UnityMCP.Editor.Handlers
             return new JObject
             {
                 ["gameObject"] = go.name,
-                ["instanceId"] = EntityIdCompat.IdOf(go),
+                ["instanceId"] = EntityIdCompat.WireIdOf(go),
                 ["components"] = page["items"],
                 ["truncated"] = page["truncated"],
                 ["next"] = page["next"]
@@ -374,7 +374,7 @@ namespace UnityMCP.Editor.Handlers
                     var objRef = prop.objectReferenceValue;
                     return new JObject
                     {
-                        ["instanceId"] = EntityIdCompat.ObjectReferenceId(prop),
+                        ["instanceId"] = EntityIdCompat.WireObjectReferenceId(prop),
                         ["name"] = objRef != null ? objRef.name : null,
                         ["type"] = objRef != null ? objRef.GetType().Name : null
                     };

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/SceneHierarchy.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/SceneHierarchy.cs
@@ -182,8 +182,8 @@ namespace UnityMCP.Editor.Handlers
                 // browsed the hierarchy has to guess at the path of the thing they are looking
                 // at, and guesses fail on any name that repeats among siblings.
                 ["path"] = UnityMCP.Editor.Tools.ObjectResolve.PathOf(go),
-                ["id"] = EntityIdCompat.IdOf(go),
-                ["instanceId"] = EntityIdCompat.IdOf(go),
+                ["id"] = EntityIdCompat.WireIdOf(go),
+                ["instanceId"] = EntityIdCompat.WireIdOf(go),
                 ["active"] = go.activeSelf,
                 ["tag"] = go.tag,
                 ["layer"] = LayerMask.LayerToName(go.layer),

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ObjectResolveTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ObjectResolveTests.cs
@@ -122,6 +122,22 @@ namespace UnityMCP.Editor.Tests
         }
 
         [Test]
+        public void TheWireFormOfAnIdResolvesBackThroughTheInvokerPath()
+        {
+            var child = ObjectResolve.Object("/ResolveRoot/Child", null);
+
+            // What a tool result carries (a string on 6.5, a number before) must come back through
+            // the same coercion a tool argument gets, without passing through a double.
+            var wire = EntityIdCompat.WireIdOf(child);
+            var roundTripped = wire.Type == Newtonsoft.Json.Linq.JTokenType.String
+                ? long.Parse((string)wire, System.Globalization.CultureInfo.InvariantCulture)
+                : (long)wire;
+
+            Assert.That(roundTripped, Is.EqualTo(EntityIdCompat.IdOf(child)));
+            Assert.That(ObjectResolve.Object(null, roundTripped), Is.SameAs(child));
+        }
+
+        [Test]
         public void AMissingSegmentReportsWhatIsThere()
         {
             var ex = Assert.Throws<McpToolException>(

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ToolInvokerTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ToolInvokerTests.cs
@@ -51,6 +51,12 @@ namespace UnityMCP.Editor.Tests
                 return new Point { X = x, Y = y };
             }
 
+            [McpTool("t_wide", "Returns the 64-bit value it was given.", Idempotency = McpIdempotency.Safe)]
+            public static long Wide([McpArg("id", "A 64-bit id")] long id)
+            {
+                return id;
+            }
+
             [McpTool("t_flag", "Returns the flag it was given.", Idempotency = McpIdempotency.Safe)]
             public static bool Flag([McpArg("enabled", "Whether enabled")] bool enabled)
             {
@@ -130,6 +136,19 @@ namespace UnityMCP.Editor.Tests
 
             Assert.That(result["x"].Value<int>(), Is.EqualTo(3));
             Assert.That(result["y"].Value<int>(), Is.EqualTo(4));
+        }
+
+        [Test]
+        public void A64BitIntegerKeepsEveryBit()
+        {
+            // A Unity 6.5 EntityId is around 5.7e17, above the 2^53 a double holds exactly. Coercing
+            // through a double rounds the low bits off, and the id then names a different object.
+            const long id = (1L << 53) + 1;
+
+            Assert.That(Invoke("t_wide", new JObject { ["id"] = id })["result"].Value<long>(), Is.EqualTo(id),
+                        "a JSON integer lost precision");
+            Assert.That(Invoke("t_wide", new JObject { ["id"] = id.ToString() })["result"].Value<long>(), Is.EqualTo(id),
+                        "a numeric string lost precision");
         }
 
         [Test]

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineTools.cs
@@ -88,7 +88,7 @@ namespace UnityMCP.Editor.Timeline
 
             // Guards against a Control track that loops back to a timeline already being reported,
             // which would otherwise recurse until the stack gave out.
-            var visited = new HashSet<int>();
+            var visited = new HashSet<long>();
 
             return DescribeDirector(director, includeClips, track, Math.Max(nestDepth, 0), visited);
         }
@@ -173,7 +173,7 @@ namespace UnityMCP.Editor.Timeline
         }
 
         private static JObject DescribeDirector(
-            PlayableDirector director, bool includeClips, string trackFilter, int nestDepth, HashSet<int> visited)
+            PlayableDirector director, bool includeClips, string trackFilter, int nestDepth, HashSet<long> visited)
         {
             var timeline = director.playableAsset as TimelineAsset;
 
@@ -195,7 +195,7 @@ namespace UnityMCP.Editor.Timeline
                 return result;
             }
 
-            if (!visited.Add(timeline.GetInstanceID()))
+            if (!visited.Add(EntityIdCompat.IdOf(timeline)))
             {
                 result["note"] = "Already reported above; a Control track loops back to it.";
                 return result;
@@ -245,7 +245,7 @@ namespace UnityMCP.Editor.Timeline
         }
 
         private static JObject DescribeClip(
-            TimelineClip clip, PlayableDirector director, int nestDepth, HashSet<int> visited)
+            TimelineClip clip, PlayableDirector director, int nestDepth, HashSet<long> visited)
         {
             var entry = new JObject
             {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
@@ -445,7 +445,7 @@ namespace UnityMCP.Editor.Tools
             {
                 ["name"] = go.name,
                 ["path"] = ObjectResolve.PathOf(go),
-                ["instanceId"] = EntityIdCompat.IdOf(go),
+                ["instanceId"] = EntityIdCompat.WireIdOf(go),
                 ["active"] = go.activeSelf,
             };
 

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs
@@ -140,7 +140,7 @@ namespace UnityMCP.Editor.Tools
             {
                 ["name"] = instance.name,
                 ["path"] = ObjectResolve.PathOf(instance),
-                ["instanceId"] = EntityIdCompat.IdOf(instance),
+                ["instanceId"] = EntityIdCompat.WireIdOf(instance),
                 ["prefab"] = normalised,
             });
         }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs
@@ -395,7 +395,7 @@ namespace UnityMCP.Editor.Tools
                 {
                     ["name"] = unityObject.name,
                     ["type"] = type.FullName,
-                    ["instanceId"] = EntityIdCompat.IdOf(unityObject),
+                    ["instanceId"] = EntityIdCompat.WireIdOf(unityObject),
                 };
             }
 

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
@@ -193,7 +193,11 @@ namespace UnityMCP.Editor.Tools
                 ["shadowResolution"] = QualitySettings.shadowResolution.ToString(),
                 ["shadowDistance"] = QualitySettings.shadowDistance,
                 ["activeBuildTarget"] = EditorUserBuildSettings.activeBuildTarget.ToString(),
+#if UNITY_2023_1_OR_NEWER
                 ["batchingStatic"] = PlayerSettings.GetStaticBatchingForPlatform(EditorUserBuildSettings.activeBuildTarget),
+#else
+                ["batchingStatic"] = JValue.CreateNull(),
+#endif
             };
         }
 

--- a/jp.shiranui-isuzu.unity-mcp/README.md
+++ b/jp.shiranui-isuzu.unity-mcp/README.md
@@ -1,245 +1,79 @@
 # Unity MCP
 
-A Unity Editor package that exposes an HTTP API for AI-driven automation via the Model Context Protocol (MCP). Claude and other MCP clients can execute C# code, inspect the scene hierarchy, control Play Mode, capture screenshots, read console logs, and more — all without leaving the editor.
+A Unity Editor package that exposes the Editor to AI agents over the Model Context Protocol (MCP), and to people and scripts over a command line. Agents can read the console, browse and edit the scene, run tests, drive Timeline and Recorder, capture screenshots, and run C# snippets.
 
-## Architecture
-
-```
- ┌──────────────────────────┐       stdio        ┌────────────────────────────┐
- │   MCP client (Claude)    │ ─────────────────▶ │   TS MCP server            │
- └──────────────────────────┘                    │   (unity-mcp-ts/dist)      │
-                                                 │                            │
- ┌──────────────────────────┐       HTTP         │  UnityConnection           │
- │  CLI (curl / Skill)      │ ─────────────────▶ │  ProjectRegistry (UDP)     │
- └──────────────────────────┘    :27180 (proxy)  │  ProjectApi :27180         │
-                                                 └────────────┬───────────────┘
-                                                      HTTP /command, /inspect etc.
-                                                              ▼
- ┌──────────────────────────┐       UDP          ┌────────────────────────────┐
- │ Unity Editor (A)         │ ────── :27183 ───▶ │  (broadcast received by TS)│
- │  McpHttpServer :27182    │                    └────────────────────────────┘
- │  Handlers + Resources    │
- └──────────────────────────┘
- ┌──────────────────────────┐
- │ Unity Editor (B)         │  (same UDP :27183 broadcast)
- │  McpHttpServer :27183    │
- └──────────────────────────┘
-```
-
-**Two connection paths:**
-
-- **Direct** — `curl http://127.0.0.1:27182/...` (no TS server needed, single-editor quickpath)
-- **Proxy** — `curl http://127.0.0.1:27180/proxy/<name>/...` (multi-project routing, automatic reload retry)
+The full documentation, including the tool list, lives in the repository README:
+https://github.com/isuzu-shiranui/UnityMCP
 
 ## Requirements
 
-- Unity 2022.3 or later
-- [Newtonsoft Json for Unity](https://docs.unity3d.com/Packages/com.unity.nuget.newtonsoft-json@3.2/manual/index.html) (com.unity.nuget.newtonsoft-json 3.2.1) — added automatically
+- Unity 2022.3 or later. The EditMode suite is verified on 2022.3, 2023.1, 2023.2, 6.0, 6.1, 6.3 and 6.5.
+- `com.unity.nuget.newtonsoft-json` 3.2.1. It is resolved automatically as a dependency.
+- Node.js 18 or later, for the MCP server and the CLI.
 
 ## Installation
 
-### Via Unity Package Manager (UPM)
+In the Package Manager choose **Add package from git URL** and enter:
 
-1. Open **Window > Package Manager**
-2. Click **+** → **Add package from git URL**
-3. Enter: `https://github.com/shiranui-isuzu/unity-mcp.git?path=jp.shiranui-isuzu.unity-mcp`
-
-### Manual
-
-Download or clone the repository and add the `jp.shiranui-isuzu.unity-mcp` folder to your project's `Packages/` directory.
-
-## Quick Start
-
-### With MCP client (Claude Desktop / Claude Code)
-
-1. Install and start the TS MCP server (see `unity-mcp-ts/README.md`)
-2. Add to your MCP client config:
-   ```json
-   {
-     "mcpServers": {
-       "unity": {
-         "command": "node",
-         "args": ["/path/to/unity-mcp-ts/build/index.js"]
-       }
-     }
-   }
-   ```
-3. Open Unity — the MCP server starts automatically (if `autoStartOnLaunch = true`)
-4. In Claude, use tools like `unity_execute_code`, `unity_browse_hierarchy`, etc.
-
-### With CLI (curl)
-
-```bash
-# Check Unity is running
-curl -s http://127.0.0.1:27182/health
-
-# Run C# code
-curl -s -X POST http://127.0.0.1:27182/execute_code \
-  -H "Content-Type: application/json" \
-  -d '{"code":"return Camera.main.name;"}'
-# {"status":"success","result":{"output":"","returnValue":"Main Camera"}}
+```
+https://github.com/isuzu-shiranui/UnityMCP.git?path=jp.shiranui-isuzu.unity-mcp
 ```
 
-See the [CLI Skill](https://github.com/shiranui-isuzu/unity-mcp) for a full reference.
+Then install the MCP server and CLI from npm:
 
-## Endpoints
+```bash
+npm install -g @shiranui_isuzu/unity-mcp
+isuzu-unity-mcp setup     # registers the server with the MCP clients found on this machine
+isuzu-unity-mcp doctor    # shows what is installed and where
+```
 
-| Endpoint | Method | Idempotency | Description |
-|---|---|---|---|
-| `/health` | GET | Safe | Server status, handlers, resources |
-| `/execute_code` | POST | Unsafe | Run C# (dynamic compilation) |
-| `/browse_hierarchy` | POST | Safe | Query scene hierarchy |
-| `/inspect` | POST | Safe/Unsafe | Read/write component properties |
-| `/capture_screenshot` | POST | Safe | Game, Scene, or Editor panel screenshot (Windows-only for panels) |
-| `/read_logs` | POST | Safe | Console logs with filtering |
-| `/play_mode` | POST | Safe/Unsafe | Play/stop/pause/step control |
-| `/command` | POST | Per-command | Menu, console, asset commands |
-| `/resource` | GET | Safe | Project packages / assemblies |
+## How it works
 
-All responses use the unified envelope: `{"status":"success"|"error","result?:{},"error?:{},"truncated?:bool,"next?:{}}`.
+When the Editor opens a project, the package starts an HTTP server on `127.0.0.1` (port 27182, moving up to 27199 if busy) and writes a descriptor file with the port and a bearer token. The MCP server and the CLI read that file to find and authenticate to the Editor. Nothing needs to be started by hand.
 
-List-returning endpoints (`/read_logs`, `/browse_hierarchy`, `/inspect` list, `/resource`) accept `limit`, `offset`, and `fields` parameters for context-efficient pagination.
+Tools are defined once, in C#. A static method with `[McpTool]` becomes a tool. Its JSON Schema is generated from the method signature and published at `GET /tools`. The MCP server forwards that catalog, so adding a tool never touches TypeScript.
 
-### `/capture_screenshot` — view options (v2.1)
+```csharp
+[McpTool("asset_find_by_type", "Find project assets of a given type.", Idempotency = McpIdempotency.Safe)]
+public static string[] FindByType(
+    [McpArg("type", "Unity type name, e.g. Material.")] string type,
+    [McpArg("limit", "Maximum paths to return.")] int limit = 50)
+{
+    return AssetDatabase.FindAssets($"t:{type}").Take(limit).Select(AssetDatabase.GUIDToAssetPath).ToArray();
+}
+```
 
-The `view` parameter accepts:
+Tools that declare `MainThread = false`, together with `/health`, `/jobs` and `/tools`, answer from a worker thread. They keep working while the Editor main thread is blocked. A call that takes longer than `syncWaitMs` (3 seconds by default) returns a job id instead of a timeout. Poll the job for the result instead of repeating the call.
 
-| Value | Description |
-|---|---|
-| `"game"` | Camera render (cross-platform) |
-| `"scene"` | Scene view camera render (cross-platform) |
-| `"inspector"` | Inspector EditorWindow (Windows only) |
-| `"hierarchy"` | Hierarchy EditorWindow (Windows only) |
-| `"project"` | Project Browser EditorWindow (Windows only) |
-| `"console"` | Console EditorWindow (Windows only) |
-| `"game_view_window"` | Game view panel (Windows only) |
-| `"scene_view_window"` | Scene view panel (Windows only) |
-| `"window:<title>"` | Any EditorWindow matched by title substring, case-insensitive (Windows only) |
-
-Editor panel capture (`inspector`, `hierarchy`, `project`, `console`, `game_view_window`, `scene_view_window`, `window:<title>`) uses Windows P/Invoke (desktop DC + BitBlt + DPI correction). Non-Windows returns `unsupported_platform` (501). The `"game"` and `"scene"` camera-based paths remain cross-platform.
-
-Response includes `windowTitle` alongside `image`, `view`, `width`, `height` when an EditorWindow is captured.
+Timeline tools appear only when `com.unity.timeline` is installed. Recorder tools appear only when both `com.unity.recorder` and `com.unity.timeline` are installed. `test_run` and `test_results` appear only when `com.unity.test-framework` is installed.
 
 ## Settings
 
-Open **Edit > Preferences > Unity MCP** (or **Project Settings > Unity MCP**).
+**Edit > Preferences > Unity MCP**
 
-| Setting | Default | Description |
+| Setting | Default | Meaning |
 |---|---|---|
-| `httpPort` | `27182` | Base HTTP port. Scans 27182–27199 for first available. |
-| `autoStartOnLaunch` | `true` | Start server automatically when Unity opens |
-| `detailedLogs` | `true` | Log each request with timestamp and latency |
-| `useUdpBroadcast` | `true` | Broadcast UDP announce packets for TS server discovery |
-| `udpBroadcastPort` | `27183` | UDP broadcast destination port |
-| `broadcastIntervalSeconds` | `30` | Interval between UDP announce packets |
-| `portPersistenceEnabled` | `true` | Persist the bound port across domain reloads via SessionState |
-| `reloadRetryMaxMs` | `15000` | Advisory value for TS/CLI clients: max retry duration during reload |
-
-> **Removed in v2.0:** `autoRestartOnPlayModeChange` — PlayMode transitions no longer restart the server. Domain reload continuity is handled via `AssemblyReloadEvents` only.
-
-### Handler enable/disable
-
-Individual handlers (e.g. `execute_code`) can be enabled or disabled in the settings UI. When disabled, the endpoint returns `{"status":"error","error":{"code":"handler_not_found",...}}`.
-
-## Multi-Editor Setup
-
-You can run multiple Unity Editor instances simultaneously. Each instance binds the next available port (27182, 27183, …).
-
-```bash
-# Discover all running instances (TS server must be running)
-curl -s http://127.0.0.1:27180/projects
-# [
-#   {"name":"ProjectA","port":27182,"state":"healthy","clientId":"ProjectA-27182"},
-#   {"name":"ProjectB","port":27183,"state":"healthy","clientId":"ProjectB-27183"}
-# ]
-
-# Send commands to each instance by name via proxy
-curl -s -X POST http://127.0.0.1:27180/proxy/ProjectA/play_mode \
-  -H "Content-Type: application/json" \
-  -d '{"action":"status"}'
-
-curl -s -X POST http://127.0.0.1:27180/proxy/ProjectB/read_logs \
-  -H "Content-Type: application/json" \
-  -d '{"limit":5}'
-```
-
-In MCP tool calls, use the `target` parameter to specify which instance to address:
-```
-unity_execute_code(code="...", target="ProjectA")
-unity_browse_hierarchy(target="ProjectB")
-```
-
-## Domain Reload Continuity
-
-When you edit scripts (or enter Play Mode with domain reload enabled), the C# domain reloads. In v2.0:
-
-- **The server port is preserved** across reloads via `SessionState`. The same port is re-bound after reload completes.
-- **The TS server retries automatically** during the reload window (ECONNREFUSED → exponential backoff for up to `reloadRetryMaxMs` ms).
-- **PlayMode transitions do not restart the server.** Only actual domain reloads cause a brief offline period.
-
-For direct CLI access during reload:
-```bash
-curl --retry 5 --retry-connrefused --retry-delay 2 -s http://127.0.0.1:27182/health
-```
-
-## v2.1 Notes
-
-### Code execution — now built-in end-to-end
-
-C# code execution is available out-of-the-box via two paths — no samples needed:
-
-- **HTTP**: `POST /execute_code` (has been built-in since v2.0)
-- **MCP tool**: `unity_execute_code` (new in v2.1 — callable from Claude Desktop / Claude Code without any additional setup)
-- **MCP prompt**: `code_execute` (new in v2.1 — provides C# code templates in MCP clients)
-
-The `UnityMCPHandlerSamples` (C#) and `UnityMCPHandlerSamplesJS` (JS) sample packages have been removed in v2.1 as they are fully superseded by these built-in alternatives. If you previously imported either sample, remove it — no code migration is required.
-
-### Editor panel screenshots — Windows only in v2.1
-
-`/capture_screenshot` now supports Inspector, Hierarchy, Project, Console, and any other EditorWindow via the new `view` values. See the [view options table](#capture_screenshot--view-options-v21) above. Non-Windows returns `unsupported_platform` (501). Camera-based `view=game` / `view=scene` remain cross-platform.
-
----
-
-## Migration Guide: v1.x → v2.0
-
-### Breaking changes
-
-1. **Unified response envelope**: All endpoints now return `{"status":..., "result":...}`. Previously some endpoints returned flat JSON (e.g. `{"output":"...","returnValue":"..."}`). Update any code that reads top-level keys:
-   - `/execute_code`: `.output` → `.result.output`, `.returnValue` → `.result.returnValue`
-   - `/capture_screenshot`: `.image` → `.result.image`
-   - `/play_mode`: `.isPlaying` → `.result.isPlaying`
-   - `/read_logs`: `.logs` → `.result.logs`
-   - All other endpoints: wrap your field access with `.result.`
-
-2. **`autoRestartOnPlayModeChange` removed**: Remove this key from any stored settings or config files.
-
-3. **Auto-active instance selection removed**: Previously the first discovered Unity instance was automatically set as active. Now:
-   - Single instance: still used automatically (convenience case)
-   - Multiple instances + no `target` + no explicit active: returns `target_required` error
-   - Fix: call `unity_setActiveClient` in your session, or pass `target` parameter in each tool call
-
-4. **ProjectApi port range**: Now uses 27180–27189 fallback range instead of fixed 27180.
-
-### curl example updates
-
-Before (v1.x):
-```bash
-curl -s -X POST http://127.0.0.1:27182/execute_code \
-  -d '{"code":"return 1;"}' | jq '.returnValue'
-```
-
-After (v2.0):
-```bash
-curl -s -X POST http://127.0.0.1:27182/execute_code \
-  -H "Content-Type: application/json" \
-  -d '{"code":"return 1;"}' | jq '.result.returnValue'
-```
+| `httpPort` | 27182 | First port to try. Moves up to 27199 if busy |
+| `autoStartOnLaunch` | true | Start the server when the Editor opens |
+| `syncWaitMs` | 3000 | Calls slower than this return a job id |
+| `detailedLogs` | true | Log each request |
 
 ## Security
 
-- The HTTP server binds to `127.0.0.1` only. It is not accessible from the network.
-- `/execute_code` can be disabled in settings if you do not want arbitrary C# execution.
-- No authentication token is required (loopback-only design assumption).
+- The server binds to `127.0.0.1` only and requires a bearer token on every request.
+- No CORS headers are sent. A web page open in a browser cannot call the server.
+- Treat the descriptor file as a credential. Anyone who can read it can run code inside the Editor.
+- `execute_code` and `menu_execute` run with the Editor's full permissions. Do not feed them untrusted code.
+
+Nothing in this package reaches a player build, Development Build included. All sources are under `Editor/` and every assembly definition is restricted to the Editor platform. CI checks both on every change.
+
+## Tests
+
+The EditMode suite lives inside the package. To run it, add the package to `testables` in the project's `Packages/manifest.json`:
+
+```json
+"testables": ["jp.shiranui-isuzu.unity-mcp"]
+```
 
 ## License
 

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "A package that provides integration with the Model Context Protocol (MCP) for Unity.",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,12 +21,6 @@ Pinned to 6000.0.x, not "whichever Editor is newest here": a gate whose meaning 
 happens to be installed on one machine is not a gate. The version actually used is recorded in
 the attestation.
 
-That pin currently also hides something worth knowing. On Unity 6000.5 the package **does not
-compile** — `Object.GetInstanceID()`, `EditorUtility.InstanceIDToObject` and
-`SerializedProperty.objectReferenceInstanceIDValue` became obsolete-as-error there, and the
-package has not been migrated to `EntityId`. Ten call sites across six files. The README claims
-2022.3 through Unity 6, so that claim is currently too broad.
-
 Options: `-Unity <path>` to pick an Editor, `-ProjectPath <dir>` to put the scratch project
 elsewhere, `-KeepProject` to keep it after a first run.
 

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,8 +1,8 @@
 {
-    "sourceHash":  "d6b6b1d5af4ae6e963b5f7bcfa83535d8431b9c093baca4d06ffa5e2d654adef",
-    "total":  230,
-    "passed":  230,
+    "sourceHash":  "7cac89b4a47b76bf50d40867f33570c42ae19989cc05874f18f0fbf9fdfe9ffa",
+    "total":  232,
+    "passed":  232,
     "failed":  0,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-07-30T23:52:48.6837114Z"
+    "ranAt":  "2026-09-03T14:56:36.7356782Z"
 }

--- a/unity-mcp-ts/CHANGELOG.md
+++ b/unity-mcp-ts/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [3.3.1] - 2026-09-03
+
+Released in step with the Unity package.
+
+### Changed
+- `@modelcontextprotocol/sdk` 1.11 to 1.30, the last 1.x line, which picks up the dependency
+  fix for GHSA-frvp-7c67-39w9. The protocol handshake is unchanged. Clients that speak the
+  2026-07-28 stateless revision still connect to stdio servers through the previous handshake
+  by default, so nothing changes for them.
+- The server instructions tell a client with several Editors open to name the project, never a
+  port. `target` takes a project name or a clientId, and `unity_list_clients` shows what is open.
+
+### Fixed
+- Unity 6.5 instance ids no longer lose precision on the way through this server. The Editor
+  sends them as JSON strings on 6.5 and later (see the Unity package changelog), and this
+  server forwards tool results without reparsing numbers, so the ids reach the model intact.
+
 ## [3.2.0] - 2026-07-28
 
 Released in step with the Unity package, which went from 23 tools to 57. No

--- a/unity-mcp-ts/README.md
+++ b/unity-mcp-ts/README.md
@@ -2,9 +2,9 @@
 
 The MCP server and CLI for [UnityMCP](https://github.com/isuzu-shiranui/UnityMCP).
 
-This package deliberately knows nothing about individual tools. The Editor publishes them at
-`GET /tools` with a JSON Schema generated from its C# signatures, and this server forwards
-that catalog. Adding a tool is a change in the Unity package alone.
+This package has no knowledge of individual tools. The Editor publishes them at `GET /tools`
+with a JSON Schema generated from its C# signatures. This server forwards that catalog. Adding
+a tool is a change in the Unity package alone.
 
 ## Architecture
 
@@ -46,11 +46,11 @@ npm link          # provides the isuzu-unity-mcp command
 isuzu-unity-mcp setup   # register with installed agents and install the skill
 ```
 
-`setup` writes to the MCP config of every supported agent it finds — Claude Code, Claude
-Desktop, Codex, Cursor, Gemini CLI — and installs the skill for those that have a skills
-directory. It updates only configs that already exist, rather than creating one for a tool
-that is not installed, and rewrites them key by key so other servers survive. Pass
-`--agent <name>` to pick one, `--no-skill` to skip skills.
+`setup` writes to the MCP config of every supported agent it finds: Claude Code, Claude
+Desktop, Codex, Cursor, and Gemini CLI. It installs the skill for those that have a skills
+directory. It updates only configs that already exist. It does not create a config for a tool
+that is not installed. It rewrites configs key by key, so other servers survive. Pass
+`--agent <name>` to pick one agent, or `--no-skill` to skip skills.
 
 ```bash
 isuzu-unity-mcp doctor          # what is installed, where, and what is stale
@@ -58,8 +58,8 @@ isuzu-unity-mcp uninstall       # lists what it would remove
 isuzu-unity-mcp uninstall --yes # removes it
 ```
 
-`uninstall` takes only the `isuzu-unity-mcp` entry out of each agent config, and refuses while an
-Editor is running, since that Editor would republish its descriptor moments later.
+`uninstall` removes only the `isuzu-unity-mcp` entry from each agent config. It refuses to run
+while an Editor is running, because that Editor would republish its descriptor right after.
 
 ## Usage
 
@@ -78,10 +78,10 @@ Editor is running, since that Editor would republish its descriptor moments late
 
 `isuzu-unity-mcp serve` starts the same server, so one binary covers both roles.
 
-The Editor need not be running at startup. Until one appears the server answers `tools/list`
-from its cached catalog under the state root, then sends `tools/list_changed` once it has a live
-catalog. Clients ask for the tool list the moment they connect, which is routinely before any
-Editor is open; answering from the last known catalog beats answering "no tools".
+The Editor does not need to be running at startup. Until one appears, the server answers
+`tools/list` from its cached catalog under the state root. Once it has a live catalog, it sends
+`tools/list_changed`. Clients ask for the tool list as soon as they connect, which is often before
+any Editor is open. The cached catalog lets the client see the tools in that case.
 
 ### As a CLI
 
@@ -99,12 +99,12 @@ isuzu-unity-mcp call <tool> --project MyGame   # when several Editors are open
 isuzu-unity-mcp call <tool> --raw              # print the whole envelope
 ```
 
-The CLI talks to the Editor directly rather than through this server, so it works with no MCP
-client running. Errors print to stderr and set a non-zero exit code.
+The CLI talks to the Editor directly, not through this server. It works with no MCP client
+running. Errors print to stderr and set a non-zero exit code.
 
 `--file` sends `execute_code` snippets base64-encoded. Passing C# through a shell and a JSON
-encoder loses the backslashes in its string literals, and the failure surfaces as a compile
-error in generated source the caller never sees.
+encoder loses the backslashes in its string literals. The failure then appears as a compile
+error in generated source that the caller never sees.
 
 ### As an HTTP proxy
 
@@ -117,7 +117,7 @@ curl -X POST http://127.0.0.1:27180/proxy/MyProject/tools/play_mode_status \
 ```
 
 The proxy supplies the bearer token, so requests through it need no credential handling. It
-only exists while an MCP client has this server running — for a standalone path, use the CLI.
+exists only while an MCP client has this server running. For a standalone path, use the CLI.
 
 ## Multi-instance behaviour
 
@@ -127,31 +127,30 @@ several can run at once.
 With more than one running, the target is resolved in this order:
 
 1. An explicit `target` (MCP) or `--project` (CLI). An exact project name or clientId wins
-   over a substring; an ambiguous substring is refused with the candidates named, because
-   silently picking one means a write can land in the wrong project and still succeed.
+   over a substring match. An ambiguous substring is refused and the candidates are listed.
+   Picking one silently could send a write to the wrong project.
 2. The active client, if `unity_set_active_client` was called.
 3. **The project containing the working directory.** A shell inside a project, or an MCP
-   client opened in one, has already said which project it means. Nested projects resolve to
-   the deepest containing root.
+   client opened in one, already identifies the project. Nested projects resolve to the
+   deepest containing root.
 4. Otherwise the call is refused and the candidates are listed.
 
 `isuzu-unity-mcp projects` marks the entry step 3 would choose with `containsWorkingDirectory`.
 
-Descriptors are checked for a live pid, so an Editor that crashed rather than quit cannot
-linger as a phantom instance. A withdrawn descriptor unregisters its instance immediately: a
-clean shutdown is a more definite signal than any health poll result.
+Descriptors are checked for a live pid, so an Editor that crashed instead of quitting does not
+linger as a phantom instance. A withdrawn descriptor unregisters its instance immediately,
+without waiting for a health poll.
 
 ## Reload resilience
 
 A domain reload takes the Editor's HTTP server down for a few seconds. The instance moves to
-`reloading` rather than being dropped, requests retry within `MCP_RELOAD_RETRY_MAX_MS`, and
-the Editor keeps its descriptor and token across the reload so the reconnect needs no new
-credential.
+`reloading` and is not dropped. Requests retry within `MCP_RELOAD_RETRY_MAX_MS`. The Editor
+keeps its descriptor and token across the reload, so the reconnect needs no new credential.
 
 ## Retry safety
 
-Each tool declares its own idempotency in the catalog, and only `safe` calls are retried after
-a post-handshake failure. Retrying an `unsafe` call could apply its side effect twice.
+Each tool declares its own idempotency in the catalog. Only `safe` calls are retried after a
+post-handshake failure. Retrying an `unsafe` call could apply its side effect twice.
 
 ## Environment variables
 
@@ -186,16 +185,17 @@ npm run lint      # eslint
 npm run build     # tsc
 ```
 
-CI runs all four on every pull request, and additionally checks that the two packages agree on
-their version and that the protocol version the Editor advertises matches its package.
+CI runs all four on every pull request. It also checks that the two packages agree on their
+version, and that the protocol version the Editor advertises matches its package.
 
 ## Migrating from v2
 
-The handler system is gone: `src/handlers/`, `HandlerAdapter`, `HandlerDiscovery`, the
-registries and the `Base*Handler` classes were all a second copy of definitions the Editor
-already owned, and the two drifted. If you had written a TypeScript handler, rewrite it as an
-`[McpTool]` method in C#; it will then be reachable from MCP clients and the CLI alike.
+The handler system is gone. `src/handlers/`, `HandlerAdapter`, `HandlerDiscovery`, the
+registries and the `Base*Handler` classes have been removed. They were a second copy of
+definitions the Editor already owned, and the two copies drifted apart. If you wrote a
+TypeScript handler, rewrite it as an `[McpTool]` method in C#. It is then reachable from MCP
+clients and the CLI alike.
 
-MCP resources are withdrawn. Their TypeScript implementations posted to an endpoint the Editor
-never registered, so they had never worked; `project_assemblies` and `project_packages` cover
-the same ground as tools.
+MCP resources are removed. Their TypeScript implementations posted to an endpoint the Editor
+never registered, so they never worked. The tools `project_assemblies` and `project_packages`
+cover the same ground.

--- a/unity-mcp-ts/package-lock.json
+++ b/unity-mcp-ts/package-lock.json
@@ -1,20 +1,19 @@
 {
-  "name": "unity-mcp-ts",
-  "version": "3.0.0",
+  "name": "@shiranui_isuzu/unity-mcp",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "unity-mcp-ts",
-      "version": "3.0.0",
-      "license": "ISC",
+      "name": "@shiranui_isuzu/unity-mcp",
+      "version": "3.3.1",
+      "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.0",
-        "zod": "^3.24.2"
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "zod": "^3.25.76"
       },
       "bin": {
-        "unity-mcp": "build/cli.js",
-        "unity-mcp-server": "build/index.js"
+        "isuzu-unity-mcp": "build/cli.js"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -28,6 +27,9 @@
         "tsx": "^4.19.3",
         "typescript": "^5.8.2",
         "undici": "^6.19.8"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1071,6 +1073,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1593,25 +1607,66 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
-      "integrity": "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2077,6 +2132,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2310,23 +2404,40 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -2606,15 +2717,16 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -2701,9 +2813,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2889,9 +3001,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3240,18 +3352,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -3282,10 +3395,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -3293,14 +3410,13 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3346,6 +3462,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -3394,9 +3526,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -3407,7 +3539,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3769,6 +3905,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3777,19 +3922,23 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/human-signals": {
@@ -3803,15 +3952,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -3888,6 +4041,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4673,6 +4835,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4726,6 +4897,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4868,12 +5045,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -4929,15 +5110,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -4990,12 +5175,32 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/neo-async": {
@@ -5238,12 +5443,13 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -5457,12 +5663,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -5493,27 +5700,31 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/react-is": {
@@ -5528,6 +5739,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5675,26 +5895,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5715,31 +5915,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -5749,6 +5953,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -5779,14 +5987,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -5798,13 +6006,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5926,9 +6134,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6262,17 +6470,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -6534,21 +6759,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/unity-mcp-ts/package.json
+++ b/unity-mcp-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiranui_isuzu/unity-mcp",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "build/index.js",
   "type": "module",
   "bin": {
@@ -28,8 +28,8 @@
   "license": "MIT",
   "description": "MCP server and CLI for driving the Unity Editor. Pairs with the jp.shiranui-isuzu.unity-mcp Unity package.",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.0",
-    "zod": "^3.24.2"
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/unity-mcp-ts/skills/isuzu-unity-mcp/SKILL.md
+++ b/unity-mcp-ts/skills/isuzu-unity-mcp/SKILL.md
@@ -19,8 +19,8 @@ isuzu-unity-mcp tools      # what this Editor publishes, with argument names
 isuzu-unity-mcp health     # server state, queue depth, running jobs
 ```
 
-> Requires UnityMCP v3. On v2 there is no `isuzu-unity-mcp` binary and endpoints are unauthenticated
-> on `127.0.0.1:27182`; see the v2 section at the bottom.
+> Requires UnityMCP v3. v2 has no `isuzu-unity-mcp` binary, and its endpoints are unauthenticated
+> on `127.0.0.1:27182`. See the v2 section at the bottom.
 
 ## デバッグの鉄則: まずコンソールを読む (必須・最優先)
 
@@ -47,11 +47,11 @@ isuzu-unity-mcp call <tool> --project MyGame               # when several Editor
 isuzu-unity-mcp call <tool> --raw                          # whole envelope, not just the result
 ```
 
-Values are typed automatically: `--limit 20` sends a number, `--active_only true` a boolean.
-Errors print to stderr and set a non-zero exit code, so these compose in scripts.
+Values are typed automatically. `--limit 20` sends a number and `--active_only true` sends a boolean.
+Errors print to stderr and set a non-zero exit code, so the commands can be used in scripts.
 
-Run `isuzu-unity-mcp tools` for the authoritative list — it comes from the Editor, so it is never
-out of date with the version you are talking to.
+Run `isuzu-unity-mcp tools` for the authoritative list. It comes from the Editor, so it always
+matches the version you are talking to.
 
 ## Execute C# code
 
@@ -67,21 +67,21 @@ EOF
 isuzu-unity-mcp call execute_code --file /tmp/snippet.cs
 ```
 
-`--file` sends the snippet base64-encoded. Passing C# through a shell **and** a JSON encoder
-loses the backslashes in string literals, and the failure surfaces as a compile error naming
-generated source you never see ("Unrecognized escape sequence", "Newline in constant"). Using
-`--file` removes both layers.
+`--file` sends the snippet base64-encoded. Passing C# through a shell and a JSON encoder
+loses the backslashes in string literals. The failure then appears as a compile error in
+generated source you never see ("Unrecognized escape sequence", "Newline in constant").
+`--file` avoids both layers.
 
 Namespaces already imported: `System`, `System.Collections`, `System.Collections.Generic`,
-`System.Linq`, `System.Threading.Tasks`, `UnityEngine`, `UnityEditor`. Write statements only —
-no class or method wrapper. `return <expr>;` surfaces a value; `Debug.Log` output is captured
+`System.Linq`, `System.Threading.Tasks`, `UnityEngine`, `UnityEditor`. Write statements only,
+with no class or method wrapper. `return <expr>;` returns a value. `Debug.Log` output is captured
 separately.
 
-Return values are serialized structurally, so returning a list gives an array. An `await`ing
-snippet returns no value: the Editor will not block its main thread on an incomplete Task.
+Return values are serialized structurally, so returning a list gives an array. A snippet that
+uses `await` returns no value. The Editor does not block its main thread on an incomplete Task.
 
-Identical snippets are compiled once and reused. Distinct ones each load an assembly that
-cannot be unloaded, so a long session of one-off snippets grows the domain until a reload.
+Identical snippets are compiled once and reused. Each distinct snippet loads an assembly that
+cannot be unloaded. A long session of one-off snippets therefore grows the domain until the next reload.
 
 ## Common tools
 
@@ -114,8 +114,8 @@ cannot be unloaded, so a long session of one-off snippets grows the domain until
 
 | Tool | Purpose |
 |---|---|
-| `shader_errors` | Compilation errors. **A broken shader renders magenta and never says so** — ask after every shader edit |
-| `shader_info` / `material_read` / `material_set` | What a frame is drawn from, as opposed to the shader's defaults |
+| `shader_errors` | Compilation errors. **A broken shader renders magenta and never says so.** Run this after every shader edit |
+| `shader_info` / `material_read` / `material_set` | The values a frame is actually drawn with, not the shader's defaults |
 | `render_pipeline_info` | The pipeline actually in force. **The quality level overrides graphics settings** |
 | `render_camera_info` | View, projection and GPU projection matrices, for checking a value against a CPU replica |
 | `render_compare --before a.png --after b.png` | Differences as numbers |
@@ -127,7 +127,7 @@ cannot be unloaded, so a long session of one-off snippets grows the domain until
 - **The `path` these tools take is the one `scene_browse_hierarchy` returns.** It resolves
   inactive objects, and carries an index only when a sibling name repeats: `/Canvas/Button[1]/Text`.
 - **A scene edit during Play Mode succeeds and is reverted when Play Mode stops.** The response
-  carries `playModeWarning` when that applies. Asset edits made at the same moment do survive.
+  carries `playModeWarning` in that case. Asset edits made during Play Mode do survive.
 | `scene_browse_hierarchy --name Player --limit 20` | Hierarchy; also filters `component`, `tag`, `active_only`, `max_depth` |
 | `inspect_list --game_object_path Player --component_type Transform` | Discover property paths |
 | `inspect_read --game_object_path Player --component_type Transform --property_path m_LocalPosition` | Read one property |
@@ -137,7 +137,7 @@ cannot be unloaded, so a long session of one-off snippets grows the domain until
 | `menu_execute --menu_item "File/Save"` | Invoke a menu item |
 | `project_packages` / `project_assemblies` | Project metadata |
 
-**Timeline and Recorder** — present only when `com.unity.timeline` / `com.unity.recorder` are installed.
+**Timeline and Recorder**. These tools are present only when `com.unity.timeline` / `com.unity.recorder` are installed.
 
 | Tool | Purpose |
 |---|---|
@@ -153,15 +153,15 @@ cannot be unloaded, so a long session of one-off snippets grows the domain until
 | `timeline_create_track --type control --name Drive` | Add a track |
 | `timeline_create_clip --track Drive --control_source /ChildDirector` | Add a clip; nests a child timeline in one call |
 
-Two things about the editing tools worth knowing before trusting a result:
+Two things to know about the editing tools before trusting a result:
 
-- **They report the value that landed, not the one you asked for.** Timeline silently discards
-  writes a clip type does not support — an Activation clip accepts a speed multiplier and keeps
-  1.0 — so anything that did not take is listed in `ignored` with the reason. Read it.
+- **They report the value that was applied, not the one you asked for.** Timeline silently discards
+  writes a clip type does not support. For example, an Activation clip accepts a speed multiplier
+  and keeps 1.0. Anything that was not applied is listed in `ignored` with the reason. Read it.
 - **Create the timeline before adding tracks to it.** `timeline_create_track` refuses on a timeline
-  that is not yet an asset, because Timeline would build the track in memory only and drop it at the
-  next domain reload, with no public API to persist it afterwards. `timeline_create` is the entry
-  point that gets the order right.
+  that is not yet an asset. Timeline would otherwise build the track in memory only and drop it at
+  the next domain reload, and there is no public API to persist it afterwards. `timeline_create`
+  performs the steps in the right order.
 
 Recording is a track on the timeline, so **the frame rate comes from the timeline** and is not an
 argument here. Sources: `game_view`, `active_camera`, `main_camera`, `tagged_camera`
@@ -179,22 +179,23 @@ unity-mcp call play_mode_stop
 ```
 
 **Check the content, not the container.** Resolution, fps and frame count come from the mp4 header
-and say nothing about whether anything moved — a frozen render still reports the full frame count.
-Decode the frames and count distinct ones:
+and say nothing about whether anything moved. A frozen render still reports the full frame count.
+Decode the frames and count the distinct ones:
 
 ```bash
 ffmpeg -v error -i out.mp4 -vf scale=160:90 f_%03d.png   # distinct ≈ frames → moving
 ```
 
-Two failure modes worth knowing, because both look like "the tool did nothing":
+Two failure modes look like "the tool did nothing":
 
-- **Play Mode defers script compilation.** Unity postpones domain reload until Play Mode exits, so
-  an edited script keeps running its old build and `isCompiling` sticks true. `play_mode_stop` is
-  itself deferred to the next frame, which a backgrounded Editor never draws. Check
+- **Play Mode defers script compilation.** Unity postpones domain reload until Play Mode exits.
+  An edited script keeps running its old build and `isCompiling` stays true. `play_mode_stop` is
+  itself deferred to the next frame, and a backgrounded Editor never draws that frame. Check
   `play_mode_status` first.
-- **Timeline tracks must be created after the asset exists.** `CreateTrack` only persists a track
-  when the timeline is already an asset, so tracks built before `AssetDatabase.CreateAsset` live in
-  memory and disappear at the next domain reload — correct in the Editor, empty under Play.
+- **Timeline tracks must be created after the asset exists.** `CreateTrack` persists a track only
+  when the timeline is already an asset. Tracks built before `AssetDatabase.CreateAsset` live in
+  memory and disappear at the next domain reload. They look correct in the Editor and are empty
+  under Play.
 
 ## Common workflows
 
@@ -222,9 +223,9 @@ isuzu-unity-mcp call test_results            # poll; status goes running -> comp
 ```
 
 `test_run` does not wait for the outcome, because the run occupies the main thread for its
-whole duration. During that window `test_results` is the only tool that answers — poll it
-rather than retrying `test_run`. A `status` of `interrupted` means a domain reload happened
-mid-run and the outcome was lost; start the run again.
+whole duration. During that window `test_results` is the only tool that answers. Poll it
+instead of retrying `test_run`. A `status` of `interrupted` means a domain reload happened
+mid-run and the outcome was lost. Start the run again.
 
 ### Prove a rendering change did something
 
@@ -234,9 +235,9 @@ isuzu-unity-mcp call capture_screenshot --view game --save_path /tmp/before.png
 isuzu-unity-mcp call render_compare --before /tmp/before.png --after /tmp/after.png
 ```
 
-Compare rather than look. Screenshot colours are post-tonemap, so absolute values do not settle
-an argument; changed-pixel counts and where they are do. Passing `save_path` keeps both images
-out of the conversation entirely.
+Compare the images instead of looking at them. Screenshot colours are post-tonemap, so absolute
+values are not reliable. Changed-pixel counts and their locations are. Passing `save_path` keeps
+both images out of the conversation.
 
 ### Save a screenshot to a file
 
@@ -268,7 +269,7 @@ Work slower than about three seconds returns a job id instead of a result:
 isuzu-unity-mcp jobs execute_code-3
 ```
 
-**Do not repeat the call.** The work is still running; repeating it runs it twice.
+**Do not repeat the call.** The work is still running. Repeating the call runs it twice.
 
 ## Errors
 
@@ -282,8 +283,8 @@ isuzu-unity-mcp jobs execute_code-3
 
 ## Talking to a v2 Editor
 
-v2 has no CLI and no authentication. Endpoints live on `127.0.0.1:27182` (scanning to 27199),
-take different names, and `/read_logs` uses `count` rather than `limit`:
+v2 has no CLI and no authentication. Endpoints live on `127.0.0.1:27182` (scanning up to 27199)
+and have different names. `/read_logs` uses `count` instead of `limit`:
 
 ```bash
 curl -s http://127.0.0.1:27182/health
@@ -291,5 +292,5 @@ curl -s -X POST http://127.0.0.1:27182/read_logs \
   -H "Content-Type: application/json" -d '{"count":30,"type":"error"}'
 ```
 
-Note that v2 returns HTTP 504 after 10 seconds while **continuing to run the work**, so a retry
-on timeout executes it twice. v3 returns a job id instead.
+v2 returns HTTP 504 after 10 seconds and **keeps running the work**. A retry on timeout therefore
+executes it twice. v3 returns a job id instead.

--- a/unity-mcp-ts/src/index.ts
+++ b/unity-mcp-ts/src/index.ts
@@ -47,6 +47,11 @@ async function main() {
           "Requires a Unity Editor to be running with the jp.shiranui-isuzu.unity-mcp package",
           "installed; it is discovered automatically. Which tools exist depends on that project's",
           "packages, so Timeline and Recorder tools appear only where those packages are present.",
+          "",
+          "With several Editors open, name the project — never a port. `target` accepts a project",
+          "name (exact, then case-insensitive substring) or a clientId, and unity_list_clients",
+          "shows what is open. Asking the user which port to use is never the right move: call",
+          "unity_list_clients and pick by project name, or pass `target` on the call itself.",
         ].join("\n"),
       }
     );


### PR DESCRIPTION
## Fixes

- **Unity 2022.3 compiles again** (#20). Cherry-picks #21 by @takara2314 as is: `PlayerSettings.GetStaticBatchingForPlatform` exists only from 2023.1, so `render_pipeline_info` reports `batchingStatic` as null on 2022.3.
- **Unity 6.5 instance ids survive the trip through JavaScript.** A 6.5 EntityId is about 5.7e17, above the 2^53 a JSON number keeps exactly. The id was rounded twice, by the MCP server and by the Editor's argument coercion, and every id-addressed call on 6.5 failed with `not_found`. On 6.5 and later `instanceId` is a JSON string; 64-bit arguments accept an integer or a string without going through a double. Earlier Unity versions are unchanged.
- Settings window no longer freezes the Editor during a domain reload (already on main as 998ca5c).
- `timeline_inspect` visited set is 64-bit, so a Control track looping back to its own timeline is still detected on 6.5.

## Maintenance

- `@modelcontextprotocol/sdk` 1.11 → 1.30 (last 1.x line, GHSA-frvp-7c67-39w9 dependency fix). Handshake unchanged; `npm audit --omit=dev` clean.
- Server instructions tell a client with several Editors open to name the project, never a port.
- Plain wording across the READMEs and the skill. The UPM package README described v2 (UDP discovery, `/command`, no authentication, a non-existent git URL); it now describes v3.
- Tool count in the root READMEs corrected to 68.

## Verification

EditMode suite, 232 tests, on a fresh project per version pointing at this working tree:

| Unity | Result |
|---|---|
| 2022.3.9f1 | 232/232 |
| 2022.3.22f1 | 232/232 (fails to compile on `main`, reproduced) |
| 2023.1.13f1 | 232/232 |
| 2023.2.20f1 | 232/232 |
| 6000.0.35f1 | 232/232 (attestation) |
| 6000.1.17f1 | 232/232 |
| 6000.3.19f1 | 232/232 |
| 6000.5.10f1 | 232/232 (228/232 on `main`: the two id-rounding failures) |
| 6000.7.0a3 | 232/232 |

Live on a 6000.5.10f1 Editor: `scene_browse_hierarchy` → `inspect_list` with the returned id fails with `GameObject not found` on 3.3.0 and succeeds on this branch.

TypeScript: `tsc` clean, Jest 175/175, lint clean, stdio `initialize` + `tools/list` against the built server on SDK 1.30 returns 69 tools.
