### PR TITLE
fix: the two install entry points both worked only by accident

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,21 @@ jobs:
             console.log(names.size + ' tools (' + bare + ' without the optional packages), all documented and counted in docs/tools.md, docs/en/tools.md and both READMEs');
           "
 
+      # The install scripts are fetched and piped into a shell, so their first byte is parsed
+      # rather than displayed. A UTF-8 BOM there makes PowerShell read the leading param block as
+      # an assignment and refuse the whole script, which breaks the install line the READMEs and
+      # the guide print while the file still looks correct in every editor.
+      - name: Install scripts have no byte order mark
+        run: |
+          STATUS=0
+          for f in install.ps1 install.sh; do
+            if [ "$(head -c 3 "$f" | od -An -tx1 | tr -d ' \n')" = "efbbbf" ]; then
+              echo "$f starts with a UTF-8 BOM; it is piped into a shell and will fail to parse"
+              STATUS=1
+            fi
+          done
+          exit $STATUS
+
       # The endpoint is the whole contract between the CLI and the Editor. A client configured
       # by hand against the wrong path gets a connection that opens and then answers nothing.
       - name: Endpoint documented

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-﻿#requires -version 5.1
+#requires -version 5.1
 <#
 .SYNOPSIS
   Installs isuzu-unity-cli from GitHub Releases (isuzu-shiranui/UnityMCP).

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/ProgramTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/ProgramTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json.Nodes;
 using IsuzuUnityCli.Cli;
 using IsuzuUnityCli.Commands;
@@ -44,7 +45,17 @@ public sealed class ProgramTests
         var (context, output, _) = Context();
 
         Assert.Equal(0, await Program.Run(["--version"], context));
-        Assert.Equal("4.0.0" + Environment.NewLine, output.ToString());
+
+        // Read from the assembly rather than written here as a literal. A literal has to be
+        // edited on every release, and the edit that gets forgotten fails the build over the
+        // test's own staleness rather than over anything the CLI did. What is left to assert is
+        // the part with logic in it: the build metadata after '+' is stripped.
+        var informational = typeof(Program).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+
+        Assert.Equal(informational.Split('+')[0] + Environment.NewLine, output.ToString());
+        Assert.DoesNotContain("+", output.ToString());
+        Assert.Matches(@"^\d+\.\d+\.\d+", output.ToString());
     }
 
     [Fact]

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [4.0.1] - 2026-09-05
+
+### Fixed
+- The install line the READMEs and the getting started guide print now runs. `install.ps1`
+  carried a UTF-8 BOM, and `irm` hands `iex` a string whose first character is U+FEFF, so
+  `param()` was no longer the first statement and PowerShell refused the whole script with a
+  parse error on its first parameter. The file is ASCII, so the BOM bought nothing. CI checks
+  both install scripts for one now, because they are parsed rather than displayed.
+- The Install CLI button in Preferences now opens a terminal. It ran the same one-liner through
+  `Process.Start`, and security software refuses to create a process whose command line
+  downloads and runs a script in one expression, returning access denied to the caller. The
+  button fetches the script and hands the terminal a path instead, which also leaves the script
+  on disk to read when an install fails.
+
+Neither path had been exercised against a real release before 4.0.0 existed. The CLI binary is
+unchanged from 4.0.0.
+
 ## [4.0.0] - 2026-09-04
 
 ### Breaking

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.0.0";
+        private const string FallbackVersion = "4.0.1";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Settings/McpSettingsProvider.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Settings/McpSettingsProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 using UnityEditor;
 using UnityEngine;
@@ -438,10 +439,22 @@ namespace UnityMCP.Editor.Settings
             {
                 if (Application.platform == RuntimePlatform.WindowsEditor)
                 {
+                    // Security software refuses to create a process whose command line downloads
+                    // and runs a script in one expression, and the refusal arrives as an access
+                    // denied from Process.Start rather than anything the terminal could show.
+                    // Fetching the script here and handing the terminal a path avoids that shape,
+                    // and leaves the script on disk to read when an install fails.
+                    var script = Path.Combine(Path.GetTempPath(), "isuzu-unity-cli-install.ps1");
+
+                    using (var client = new System.Net.WebClient())
+                    {
+                        client.DownloadFile(IsuzuCliLocator.InstallScriptUrlWindows, script);
+                    }
+
                     Process.Start(new ProcessStartInfo
                     {
                         FileName = "powershell.exe",
-                        Arguments = $"-NoExit -ExecutionPolicy Bypass -Command \"irm {IsuzuCliLocator.InstallScriptUrlWindows} | iex\"",
+                        Arguments = $"-NoExit -ExecutionPolicy Bypass -File \"{script}\"",
                         UseShellExecute = true,
                     });
                 }

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "A package that provides integration with the Model Context Protocol (MCP) for Unity.",

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "301f55ad536883c6a02ca1b6bb2d0048b585364c2f587d7c2c9ec7d432bb5bd8",
+    "sourceHash":  "944bcfa1f06ddfed30b5c526b3a585538ddd22e754d9884e80309c957593d802",
     "total":  488,
     "passed":  487,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-04T15:53:37.3238753Z"
+    "ranAt":  "2026-09-04T15:57:31.4265818Z"
 }

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "3701f3f31946c416749ff653be141bd534525a73e66d2fe0f301f41c7cf1b571",
+    "sourceHash":  "301f55ad536883c6a02ca1b6bb2d0048b585364c2f587d7c2c9ec7d432bb5bd8",
     "total":  488,
     "passed":  487,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-04T14:41:58.7709612Z"
+    "ranAt":  "2026-09-04T15:53:37.3238753Z"
 }


### PR DESCRIPTION
install.ps1 carried a UTF-8 BOM. The READMEs and the getting started guide
tell a Windows user to pipe it into iex, and irm hands iex a string whose
first character is U+FEFF, so param() is no longer the first statement and
the whole script is refused with a parse error on its first parameter. The
file is ASCII, so the BOM bought nothing. CI now checks both install scripts
for one, because they are parsed rather than displayed.

The Install button in Preferences ran the same one-liner through
Process.Start. Security software refuses to create a process whose command
line downloads and runs a script in one expression, and returns access
denied to the caller, so the button failed with nothing the user could act
on. It now fetches the script and hands the terminal a path, which also
leaves the script on disk to read when an install fails.

Neither path had been run against a real release before today: the release
that made them reachable is twenty minutes old.

Verified: EditMode 488 (487 passed, 1 GUI-only skipped) on 6000.0.35f1;
the button's new sequence run in a live Editor, download and process start
both succeeding where the old one raised access denied; the BOM-stripped
script installing 4.0.0 with its checksum verified.