### PR TITLE
fix: the console tools answered with the Console window's filter applied

### DIFF
--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [4.0.2] - 2026-09-05
+
+### Fixed
+- `console_read_logs` and `console_get_count` say when the Console window is withholding
+  entries. Unity's `LogEntries.GetCount` answers with that window's own filter applied: its
+  Error, Warning and Log toggles and the text in its search box. A project with 25 entries
+  reported 9 with the Log toggle off and 0 with anything typed in the search box, and neither
+  answer said why. An agent checking whether something failed was told nothing had. The reply
+  now carries `hiddenByConsoleFilter` and a sentence naming the cause, derived from
+  `GetCountsByType`, which ignores the filter. Nothing in the user's Console window is changed
+  to produce it: a tool that reads should not rewrite the window it reads from.
+
+The other half of this was already closed. `console_set_filter` is deliberately not a tool
+because setting that filter narrows every later read, and the note in `ConsoleTools.cs` records
+it. What remained was the same filter set by hand, by the person at the Editor.
+
 ## [4.0.1] - 2026-09-05
 
 ### Fixed
@@ -10,7 +26,9 @@
   both install scripts for one now, because they are parsed rather than displayed.
 - The Install CLI button in Preferences now opens a terminal. It ran the same one-liner through
   `Process.Start`, and security software refuses to create a process whose command line
-  downloads and runs a script in one expression, returning access denied to the caller. The
+  downloads and runs a script in one expression, returning access denied to the caller.
+  Windows Defender records it as `Trojan:Win32/Commando.A!ml` against the command line, not
+  against any file. The
   button fetches the script and hands the terminal a path instead, which also leaves the script
   on disk to read when an install fails.
 

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.0.1";
+        private const string FallbackVersion = "4.0.2";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/ConsoleCommandHandler.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/ConsoleCommandHandler.cs
@@ -107,12 +107,21 @@ namespace UnityMCP.Editor.Handlers
 
                 if (count <= 0 || startRow >= totalCount)
                 {
-                    return new JObject
+                    var noneVisible = new JObject
                     {
                         ["success"] = true,
                         ["logs"] = new JArray(),
                         ["totalCount"] = totalCount
                     };
+
+                    var withheld = HiddenByTheConsoleWindow(totalCount);
+                    if (withheld > 0)
+                    {
+                        noneVisible["hiddenByConsoleFilter"] = withheld;
+                        noneVisible["note"] = FilteringNotice(withheld);
+                    }
+
+                    return noneVisible;
                 }
 
                 // Begin getting entries
@@ -203,14 +212,25 @@ namespace UnityMCP.Editor.Handlers
                 warningCount = (int)parameters[1];
                 logCount = (int)parameters[2];
 
-                return new JObject
+                var visible = (int)GetCountMethod.Invoke(null, null);
+
+                var result = new JObject
                 {
                     ["success"] = true,
-                    ["totalCount"] = (int)GetCountMethod.Invoke(null, null),
+                    ["totalCount"] = visible,
                     ["errorCount"] = errorCount,
                     ["warningCount"] = warningCount,
                     ["logCount"] = logCount
                 };
+
+                var hidden = HiddenByTheConsoleWindow(visible);
+                if (hidden > 0)
+                {
+                    result["hiddenByConsoleFilter"] = hidden;
+                    result["note"] = FilteringNotice(hidden);
+                }
+
+                return result;
             }
             catch (Exception ex)
             {
@@ -246,6 +266,40 @@ namespace UnityMCP.Editor.Handlers
                     ["error"] = ex.Message
                 };
             }
+        }
+
+/// <summary>
+        /// How many entries the Console window is hiding right now, or zero.
+        /// </summary>
+        /// <remarks>
+        /// GetCount answers with the window's own filter applied: its Error, Warning and Log
+        /// toggles and the text in its search box. GetCountsByType ignores both. A reader that
+        /// only calls GetCount is told a smaller number with nothing to say why, and a search
+        /// box left with text in it reports zero entries while the Console holds hundreds.
+        /// </remarks>
+        private static int HiddenByTheConsoleWindow(int visible)
+        {
+            try
+            {
+                var counts = new object[] { 0, 0, 0 };
+                GetCountsByTypeMethod.Invoke(null, counts);
+                var everything = (int)counts[0] + (int)counts[1] + (int)counts[2];
+
+                return everything > visible ? everything - visible : 0;
+            }
+            catch (Exception)
+            {
+                // Reporting no filtering is the same answer this gave before the check existed.
+                return 0;
+            }
+        }
+
+        /// <summary>The sentence a caller needs to see when rows are being withheld.</summary>
+        private static string FilteringNotice(int hidden)
+        {
+            return $"The Console window is filtering: {hidden} more entries exist than are " +
+                   "reported here. Its Error, Warning and Log toggles and its search box apply " +
+                   "to this call. Turn the toggles on and clear the search box to see them all.";
         }
 
         /// <summary>

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ConsoleFilterTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ConsoleFilterTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Reflection;
+
+using Newtonsoft.Json.Linq;
+
+using NUnit.Framework;
+
+using UnityEditor;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// The Console window's own filter applies to the API the console tools read through, so a
+    /// window with its Log toggle off or text in its search box makes them answer with fewer
+    /// entries, or none, and say nothing about it. A reader cannot tell that apart from a quiet
+    /// project.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ConsoleFilterTests
+    {
+        private const int LogLevelLog = 128;
+
+        private static readonly Type LogEntries =
+            typeof(EditorWindow).Assembly.GetType("UnityEditor.LogEntries");
+
+        private static MethodInfo Method(string name)
+        {
+            return LogEntries?.GetMethod(name, BindingFlags.Public | BindingFlags.Static);
+        }
+
+        [Test]
+        public void TheWindowsSeverityToggleChangesWhatGetCountReports()
+        {
+            var getCount = Method("GetCount");
+            var setFlag = Method("SetConsoleFlag");
+            var byType = Method("GetCountsByType");
+
+            if (getCount == null || setFlag == null || byType == null)
+            {
+                Assert.Ignore("UnityEditor.LogEntries does not expose the methods this covers on this Editor.");
+            }
+
+            UnityEngine.Debug.Log("ConsoleFilterTests: an entry to count.");
+
+            var visible = (int)getCount.Invoke(null, null);
+            int filtered;
+
+            try
+            {
+                setFlag.Invoke(null, new object[] { LogLevelLog, false });
+                filtered = (int)getCount.Invoke(null, null);
+            }
+            finally
+            {
+                setFlag.Invoke(null, new object[] { LogLevelLog, true });
+            }
+
+            Assert.That(filtered, Is.LessThan(visible),
+                "with the Log toggle off the window reports fewer entries; if this stops being true the tools no longer need to report the filter");
+            Assert.That((int)getCount.Invoke(null, null), Is.EqualTo(visible), "the toggle was not restored");
+        }
+
+        [Test]
+        public void GetCountsByTypeIgnoresTheWindowsFilter()
+        {
+            var getCount = Method("GetCount");
+            var setFlag = Method("SetConsoleFlag");
+            var byType = Method("GetCountsByType");
+
+            if (getCount == null || setFlag == null || byType == null)
+            {
+                Assert.Ignore("UnityEditor.LogEntries does not expose the methods this covers on this Editor.");
+            }
+
+            UnityEngine.Debug.Log("ConsoleFilterTests: an entry to count.");
+
+            var unfilteredBefore = SumByType(byType);
+            int unfilteredWhileHidden;
+
+            try
+            {
+                setFlag.Invoke(null, new object[] { LogLevelLog, false });
+                unfilteredWhileHidden = SumByType(byType);
+            }
+            finally
+            {
+                setFlag.Invoke(null, new object[] { LogLevelLog, true });
+            }
+
+            // This is what lets the tools detect the filter without touching the user's window.
+            Assert.That(unfilteredWhileHidden, Is.EqualTo(unfilteredBefore),
+                "GetCountsByType has to stay unfiltered; the console tools compare it against GetCount to find hidden rows");
+        }
+
+        [Test]
+        public void TheCountToolSaysHowManyEntriesTheWindowIsHiding()
+        {
+            var getCount = Method("GetCount");
+            var setFlag = Method("SetConsoleFlag");
+
+            if (getCount == null || setFlag == null)
+            {
+                Assert.Ignore("UnityEditor.LogEntries does not expose the methods this covers on this Editor.");
+            }
+
+            UnityEngine.Debug.Log("ConsoleFilterTests: an entry to hide.");
+
+            var handler = new UnityMCP.Editor.Handlers.ConsoleCommandHandler();
+
+            var unfiltered = handler.Execute("getCount", new JObject());
+            Assert.That(unfiltered["hiddenByConsoleFilter"], Is.Null,
+                "nothing is hidden while the window shows everything");
+
+            JObject filtered;
+
+            try
+            {
+                setFlag.Invoke(null, new object[] { LogLevelLog, false });
+                filtered = handler.Execute("getCount", new JObject());
+            }
+            finally
+            {
+                setFlag.Invoke(null, new object[] { LogLevelLog, true });
+            }
+
+            Assert.That(filtered["hiddenByConsoleFilter"], Is.Not.Null,
+                "a caller given a smaller number has to be told the window is filtering");
+            Assert.That(filtered["hiddenByConsoleFilter"].Value<int>(), Is.GreaterThan(0));
+            Assert.That(filtered["note"]?.Value<string>(), Does.Contain("Console window is filtering"));
+        }
+
+        private static int SumByType(MethodInfo byType)
+        {
+            var counts = new object[] { 0, 0, 0 };
+            byType.Invoke(null, counts);
+            return (int)counts[0] + (int)counts[1] + (int)counts[2];
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ConsoleFilterTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ConsoleFilterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90a2ec5536d0463aac14b6ba959c7ba3

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "A package that provides integration with the Model Context Protocol (MCP) for Unity.",

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "944bcfa1f06ddfed30b5c526b3a585538ddd22e754d9884e80309c957593d802",
-    "total":  488,
-    "passed":  487,
+    "sourceHash":  "8850d435796240173cd07c6a996b4dbe9ef4f77a8f959ac81d70da0ccd1eed3d",
+    "total":  491,
+    "passed":  490,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-04T15:57:31.4265818Z"
+    "ranAt":  "2026-09-05T04:59:50.5964112Z"
 }


### PR DESCRIPTION
LogEntries.GetCount reports what that window is showing, not what the
project logged: its Error, Warning and Log toggles and the text in its
search box all narrow it. A project holding 25 entries answered 9 with the
Log toggle off and 0 with anything typed in the search box, and said
nothing either time. An agent checking whether a build failed was told it
had not.

console_read_logs and console_get_count now carry hiddenByConsoleFilter and
a sentence naming the cause. The number comes from GetCountsByType, which
ignores the filter and which both paths already called. Nothing in the
user's window is touched to produce it: a tool that reads should not
rewrite the window it reads from.

Half of this was already closed. console_set_filter is deliberately not a
tool, and the note in ConsoleTools.cs records why. What remained was the
same filter set by hand at the Editor, which no code here could see.

Verified: EditMode 491 (490 passed, 1 GUI-only skipped) on 6000.0.35f1,
2022.3.22f1 and 6000.5.10f1, the three new tests passing on each; CLI 184
tests; the filtered and unfiltered counts measured against a live Editor
before and after.
