### PR TITLE
fix: the tools 4.0.0 added were missing from where people and agents look

### DIFF
--- a/isuzu-unity-cli/skills/isuzu-unity-cli/SKILL.md
+++ b/isuzu-unity-cli/skills/isuzu-unity-cli/SKILL.md
@@ -112,6 +112,7 @@ cannot be unloaded, so a long session of one-off snippets grows the domain until
 | `test_run --mode edit --assembly MyGame.Tests` | Start a test run; returns immediately |
 | `test_results` | Counts and failures; answers while the run holds the main thread |
 | `scene_browse_hierarchy --name Player --limit 20` | Hierarchy; also filters `component`, `tag`, `active_only`, `max_depth` |
+| `scene_browse_hierarchy --missing_scripts true` | Only objects carrying a component Unity cannot resolve, which is what a removed package leaves behind |
 | `inspect_list --object_path Player --component_type Transform` | Discover property paths |
 | `inspect_read --object_path Player --component_type Transform --property_path m_LocalPosition` | Read one property |
 | `inspect_write ... --json '{"property_path":"m_LocalScale","value":{"x":2,"y":2,"z":2}}'` | Write one property; a single Undo step |
@@ -119,6 +120,7 @@ cannot be unloaded, so a long session of one-off snippets grows the domain until
 | `play_mode_status` / `play_mode_play` / `play_mode_stop` | Play mode |
 | `menu_execute --menu_item "File/Save"` | Invoke a menu item |
 | `project_packages` / `project_assemblies` | Project metadata |
+| `definitions_list` | What JSON-defined tools loaded, and why one did not |
 
 ### Authoring
 
@@ -147,6 +149,28 @@ Two things to know before editing:
   inactive objects, and carries an index only when a sibling name repeats: `/Canvas/Button[1]/Text`.
 - A scene edit during Play Mode succeeds and is reverted when Play Mode stops. The response
   carries `playModeWarning` in that case. Asset edits made during Play Mode do survive.
+
+### Animator Controllers
+
+`animator_inspect` reads a controller by asset path, or through any component on a scene object
+that points at one, which is how a character with one controller per body layer is reached.
+Without a `layer` it reports the parameters and one line per layer and no states, because a
+twenty-layer controller has hundreds of them.
+
+| Tool | Purpose |
+|---|---|
+| `animator_inspect --object_path /Avatar --layer 0` | Parameters, layers, and one layer's states and transitions |
+| `animator_audit --asset_path Assets/Anim/Body.controller` | Unreferenced parameters, states with no motion, states unreachable from the default, empty layers, duplicate layer names, transitions with neither a condition nor an exit time, and Write Defaults mixed within a layer |
+| `animator_add_layer` / `animator_remove_layer` | Removing a layer destroys its sub-assets |
+| `animator_add_state` / `animator_remove_state` / `animator_set_state` | One undo step each |
+| `animator_add_transition` / `animator_remove_transition` | Conditions are passed as JSON |
+| `animator_add_parameter` / `animator_remove_parameter` | |
+| `animator_set_write_defaults` | Applies across a whole layer |
+
+A controller is a shared asset, so a write reaches every scene and character using it, and the
+`.controller` file is written before the call returns. Undo restores the controller in memory,
+not the file. Run `animator_audit` before editing: it names the states nothing can reach, which
+is usually what the person actually wanted fixed.
 
 ### Rendering and shader debugging
 
@@ -271,6 +295,18 @@ isuzu-unity-cli call input_replay --name look --then_capture scene
 
 Pass the capture to `render_compare`, or wrap all three calls as one `sequence` defined tool.
 
+Without a recording to replay, `input_pointer` and `input_key` send the events directly:
+
+```bash
+isuzu-unity-cli call input_pointer --view scene_view_window --action drag --json '{"from":[200,200],"to":[400,200],"button":1}'
+isuzu-unity-cli call input_key --view inspector --key A --character a
+```
+
+A right-drag is FPS Look and Alt+left-drag is Orbit. A drag is spread over `steps` frames by
+default, which matters: anything that reacts to time passing does not reproduce when the whole
+drag arrives in one frame. Coordinates are points, not pixels; divide a screenshot pixel by the
+`pixelsPerPoint` in the reply.
+
 ### Turning a repeated read into a named tool
 
 A `probe` defined tool turns a reflection path into a one-word call. One JSON file under `%LOCALAPPDATA%\UnityMCP\tools\<projectHash>\`:
@@ -301,6 +337,20 @@ isuzu-unity-cli jobs                         # what is queued or running
 
 `health`, `jobs` and `editor_log_tail` are answered off the main thread, so they keep working
 when nothing else does.
+
+Most often the Editor is not wedged but waiting: a modal dialog holds the main thread inside its
+own message loop until someone answers it. `health` reports it under `mainThread` as `stalledMs`
+with the dialog's title, message and buttons, and a job that is waiting for one says so.
+
+```bash
+isuzu-unity-cli call editor_dialog_list      # title, message, buttons
+isuzu-unity-cli call editor_dialog_press --button "Cancel" --confirm true
+```
+
+Read the dialog before pressing anything. `Don't Save` and `Discard` throw away unsaved work;
+`Cancel` is the safe answer, after which the cause can be fixed and the original call retried.
+Windows only — elsewhere `editor_dialog_list` answers `supported: false` and a person has to
+answer the dialog at the Editor.
 
 ## Jobs
 

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
@@ -19,7 +19,21 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>isuzu-unity-cli</ToolCommandName>
     <PackageId>IsuzuUnityCli</PackageId>
+    <Authors>Shiranui_Isuzu</Authors>
+    <Description>Drive a running Unity Editor from the terminal: read the console, compile, run tests, browse and edit the scene, capture the Game and Scene views. Pairs with the jp.shiranui-isuzu.unity-mcp Unity package, which the Editor serves MCP from directly.</Description>
+    <PackageTags>unity;unity3d;mcp;model-context-protocol;editor;cli;automation;ai-agent</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/isuzu-shiranui/UnityMCP</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/isuzu-shiranui/UnityMCP</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- nuget.org renders this on the package page. Without it the listing carries the SDK's
+         placeholder description and nothing a reader can act on. -->
+    <None Include="$(MSBuildThisFileDirectory)../../../README.en.md" Pack="true" PackagePath="README.md" Visible="false" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
     <!-- Every agent call pays process start. Native code starts in about 15 ms where the JIT

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [4.0.3] - 2026-09-05
+
+### Fixed
+- The agent skill covers the tools 4.0.0 added. `SKILL.md` is what Claude Code and Codex read to
+  learn what this can do, and it named none of the twelve `animator_` tools, neither
+  `editor_dialog_list` nor `editor_dialog_press`, nor `input_pointer`, `definitions_list` or
+  `scene_browse_hierarchy --missing_scripts`. A tool absent from the skill is a tool an agent
+  does not reach for. The dialog pair mattered most: its own section, "The Editor stopped
+  responding", offered only `health`, `jobs` and `editor_log_tail`, so the way out of a modal
+  dialog was missing from the one page a stuck agent reads.
+- The NuGet listing shows what the package is. `dotnet tool search` returned the SDK's
+  placeholder `Package Description`, the assembly name in place of an author, and no licence,
+  project link or tags. The csproj now carries a description, `Authors`, `PackageTags`,
+  `PackageLicenseExpression`, `PackageProjectUrl`, `RepositoryUrl` and the README.
+- Package Manager's Documentation link points at the getting started guide rather than the
+  repository root, and `keywords` no longer names one AI client. The package works with Claude
+  Code, Claude Desktop, Cursor, Codex, the Gemini CLI and VS Code.
+
 ## [4.0.2] - 2026-09-05
 
 ### Fixed

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.0.2";
+        private const string FallbackVersion = "4.0.3";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,19 +1,22 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
-  "description": "A package that provides integration with the Model Context Protocol (MCP) for Unity.",
+  "description": "Drive the Unity Editor from an AI agent or the terminal. The Editor serves MCP itself, so there is no second process to run, and the isuzu-unity-cli command needs no Node or .NET runtime.",
   "license": "MIT",
-  "documentationUrl": "https://github.com/isuzu-shiranui/UnityMCP",
+  "documentationUrl": "https://unity-mcp.shiranui-isuzu.dev/en/",
   "changelogUrl": "https://github.com/isuzu-shiranui/UnityMCP/blob/main/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md",
   "licensesUrl": "https://github.com/isuzu-shiranui/UnityMCP/blob/main/LICENSE",
   "keywords": [
     "unity",
     "mcp",
-    "claude",
-    "ai"
+    "model-context-protocol",
+    "editor",
+    "automation",
+    "ai-agent",
+    "cli"
   ],
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1"

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "8850d435796240173cd07c6a996b4dbe9ef4f77a8f959ac81d70da0ccd1eed3d",
+    "sourceHash":  "0064bfadff6c301923a252a36b56943129fe219fd98f8d291a1d170ffcfc0f4f",
     "total":  491,
     "passed":  490,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-05T04:59:50.5964112Z"
+    "ranAt":  "2026-09-05T05:18:49.6307721Z"
 }


### PR DESCRIPTION
SKILL.md is what Claude Code, Codex and the other agents read to learn what
this can do. It named none of the twelve animator_ tools, neither
editor_dialog_list nor editor_dialog_press, nor input_pointer,
definitions_list or scene_browse_hierarchy --missing_scripts. A tool absent
from the skill is a tool an agent does not reach for, so shipping them was
only half the work.

The dialog pair mattered most. Its own section, "The Editor stopped
responding", offered health, jobs and editor_log_tail and nothing else, so
the way out of a modal dialog was missing from the one page a stuck agent
reads. That section now says the Editor is usually waiting rather than
wedged, and which button throws away unsaved work.

nuget.org showed the SDK's placeholder "Package Description", the assembly
name in place of an author, and no licence, project link or tags. Someone
finding it through dotnet tool search had nothing to act on. The csproj
carries the real metadata and the README now.

Package Manager's Documentation link pointed at the repository root rather
than the getting started guide written for someone installing this for the
first time, and keywords still named one AI client.

Verified: EditMode 491 (490 passed, 1 GUI-only skipped) on 6000.0.35f1 with
the attestation regenerated; CLI 184 tests; dotnet pack inspected, and the
generated nuspec carries authors, description, MIT, the project URL, tags
and the bundled README.