### PR TITLE
4.0.5: a refused connection says it is probably a domain reload

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -43,7 +43,7 @@ With the VRChat Creator Companion (VCC) or ALCOM, install from the VPM repositor
 https://unity-mcp.shiranui-isuzu.dev/vpm.json
 ```
 
-Paste that URL into Add Repository. In VCC that button is on the Packages tab of the Settings page. In ALCOM it is on the Repositories page under Resources. Once the repository is added, Unity MCP appears in the project's package list.
+Paste that URL into Add Repository. In VCC that button is on the Packages tab of the Settings page. In ALCOM it is on the Repositories tab of the Packages page. Once the repository is added, Unity MCP appears in the project's package list.
 
 The one-click add link is on the getting started guide, under [If you use VCC or ALCOM](https://unity-mcp.shiranui-isuzu.dev/en/#vpm-title).
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,7 +1,7 @@
 # Unity MCP Integration Framework
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-4.0.4-brightgreen)
+![Version](https://img.shields.io/badge/version-4.0.5-brightgreen)
 ![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
 ![.NET](https://img.shields.io/badge/.NET-10-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)

--- a/README.en.md
+++ b/README.en.md
@@ -12,9 +12,11 @@ If this is your first time, start with [Getting started with Unity MCP](https://
 
 This framework opens the Unity Editor to AI agents, to people and to scripts. Running a command by hand and calling it from a script go through the same path.
 
+Any Unity project will do. A VPM repository is published as well, so it can be installed from VCC (VRChat Creator Companion) and from ALCOM.
+
 The main path is the command line `isuzu-unity-cli`. The published binaries are native, so they need no Node and no .NET runtime.
 
-MCP clients connect directly to the Streamable HTTP endpoint that the Editor itself publishes at `http://127.0.0.1:<port>/mcp`. There is no separate MCP server process.
+MCP clients connect directly to the Streamable HTTP endpoint that the Editor itself publishes at `http://127.0.0.1:<port>/mcp`. There is no separate MCP server process. Checked with Claude Code, Cursor, Codex, the Gemini CLI, VS Code and Claude Desktop.
 
 A tool is a static C# method with `[McpTool]` on it. Every tool is served to both the CLI and MCP clients.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unity MCP 統合フレームワーク
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-4.0.4-brightgreen)
+![Version](https://img.shields.io/badge/version-4.0.5-brightgreen)
 ![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
 ![.NET](https://img.shields.io/badge/.NET-10-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
 
 Unity Editor を AI エージェントに開放するフレームワークです。人が手で実行しても、スクリプトから呼んでも、同じ経路を通ります。
 
+Unity プロジェクトなら種類を問いません。VPM リポジトリも用意しているので、VCC（VRChat Creator Companion）や ALCOM からも入れられます。
+
 主な経路はコマンドラインの `isuzu-unity-cli` です。配布している実行ファイルはネイティブなので、Node も .NET ランタイムも要りません。
 
-MCP クライアントは、Editor 自身が公開する Streamable HTTP エンドポイント `http://127.0.0.1:<port>/mcp` に直接つながります。別プロセスの MCP サーバーはありません。
+MCP クライアントは、Editor 自身が公開する Streamable HTTP エンドポイント `http://127.0.0.1:<port>/mcp` に直接つながります。別プロセスの MCP サーバーはありません。Claude Code、Cursor、Codex、Gemini CLI、VS Code、Claude Desktop で確認しています。
 
 ツールは C# の static メソッドに `[McpTool]` を付けるだけで定義できます。CLI と MCP の両方に配信されます。
 

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -12,7 +12,7 @@ There is also a route that installs the package without Git. The VRChat Creator 
 https://unity-mcp.shiranui-isuzu.dev/vpm.json
 ```
 
-Paste that URL into Add Repository. In VCC it is on the Packages tab of the Settings page. In ALCOM it is on the Repositories page under Resources. The one-click add link is on the [getting started guide](https://unity-mcp.shiranui-isuzu.dev/en/#vpm-title).
+Paste that URL into Add Repository. In VCC it is on the Packages tab of the Settings page. In ALCOM it is on the Repositories tab of the Packages page. The one-click add link is on the [getting started guide](https://unity-mcp.shiranui-isuzu.dev/en/#vpm-title).
 
 Once the repository is added, Unity MCP appears in the project's package list. The repository carries every published version, so an older one can be installed from the same list.
 

--- a/isuzu-unity-cli/skills/isuzu-unity-cli/SKILL.md
+++ b/isuzu-unity-cli/skills/isuzu-unity-cli/SKILL.md
@@ -327,6 +327,26 @@ isuzu-unity-cli call capture_screenshot --view scene --max_size 512 \
   | python -c "import sys,json,base64; d=json.load(sys.stdin); open('scene.png','wb').write(base64.b64decode(d['image']))"
 ```
 
+### The connection was refused
+
+A call that comes back "unable to connect", `ECONNREFUSED`, or with the MCP server reported as
+disconnected is almost always the Editor rebuilding its domain. Changing a `.cs` file starts
+that, and the server is gone for the few seconds it takes.
+
+Wait and call again. Do not fall back to reading the code statically, and do not re-run setup:
+the registration is fine and the Editor is coming back.
+
+```bash
+isuzu-unity-cli verify                       # edits, waits out the reload, returns the errors
+isuzu-unity-cli call compile_status          # or just call again after a few seconds
+```
+
+It is worth knowing that this reaches every client at once. Two agents on one project both lose
+the connection when either of them edits a script, so the one that did nothing sees it too.
+
+If calls still fail after half a minute, the Editor is closed, or the server was stopped on the
+Preferences page.
+
 ### The Editor stopped responding
 
 ```bash

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Http/UnityHttpClient.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Http/UnityHttpClient.cs
@@ -91,7 +91,18 @@ public sealed class UnityHttpClient
                 }
 
                 var code = lastException is null ? "unknown" : RetryPolicy.CodeOf(lastException);
-                throw new UnityError(code, $"Retry budget exhausted after {attempts} attempt(s) ({elapsed}ms): {code}", null, lastException);
+                var why = code == "ECONNREFUSED"
+                    ? " Nothing is listening on the port. The Editor stops serving while it rebuilds "
+                      + "its domain, which a script change triggers and which ends on its own, so "
+                      + "the same call usually works a few seconds later. If it does not, the Editor "
+                      + "is closed or the server was stopped in Preferences."
+                    : string.Empty;
+
+                throw new UnityError(
+                    code,
+                    $"Retry budget exhausted after {attempts} attempt(s) ({elapsed}ms): {code}.{why}",
+                    null,
+                    lastException);
             }
 
             var remaining = _options.BudgetMs - elapsed;

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.0.4</Version>
+    <Version>4.0.5</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [4.0.5] - 2026-09-08
+
+### Fixed
+- A refused connection says what it usually means. The Editor stops serving while it rebuilds its
+  domain, which any script change starts, so a call made in those few seconds comes back as though
+  nothing is there. The CLI said `Retry budget exhausted: ECONNREFUSED` and left the reader to
+  guess; it now says the Editor is probably rebuilding and the same call usually works shortly
+  after. The agent skill says the same thing, and says not to fall back to reading the code
+  statically or to re-run setup, because the registration is fine.
+- The skill also says that this reaches every client at once: two agents on one project both lose
+  the connection when either of them edits a script, so the one that did nothing sees it too.
+  Transcripts show an agent reading that as its own setup being broken.
+- The English pages sent readers to ALCOM's "Repositories page under Resources". ALCOM has no
+  Resources section; its own English locale calls the sidebar item Packages and the tab
+  Repositories. The Japanese pages were already right.
+
+### Changed
+- The first screen of both READMEs says the two things people search for and could not find
+  there: that any Unity project will do and a VPM repository is published for VCC and ALCOM, and
+  which clients this has been checked with. The client names had appeared once, as lowercase
+  argument values, a hundred lines down.
+- `package.json` gains `claude`, `cursor`, `codex`, `vpm` and `vcc` as keywords.
+
 ## [4.0.4] - 2026-09-05
 
 ### Fixed

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.0.4";
+        private const string FallbackVersion = "4.0.5";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -16,7 +16,12 @@
     "editor",
     "automation",
     "ai-agent",
-    "cli"
+    "cli",
+    "claude",
+    "cursor",
+    "codex",
+    "vpm",
+    "vcc"
   ],
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1"

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "Drive the Unity Editor from an AI agent or the terminal. The Editor serves MCP itself, so there is no second process to run, and the isuzu-unity-cli command needs no Node or .NET runtime.",

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "686b20cc6ef8b548cef10692aa02d56265e3a1917b92b0edf3b30c21d7bf4c37",
+    "sourceHash":  "1f509e2af6164316c542954c053b395f793f7fac94169cf538ad9cb368c3e926",
     "total":  508,
     "passed":  507,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-05T10:30:34.8699507Z"
+    "ranAt":  "2026-09-08T00:23:53.8720972Z"
 }

--- a/site/en/index.html
+++ b/site/en/index.html
@@ -51,7 +51,7 @@
       <p class="code-label">If the link does nothing, add this URL by hand</p>
       <pre><code>https://unity-mcp.shiranui-isuzu.dev/vpm.json</code></pre>
 
-      <p class="aside">In VCC that is the Add Repository button on the Packages tab of the Settings page. In ALCOM it is the Add Repository button on the Repositories page under Resources. Once the repository is added, Unity MCP appears in the project's package list. If you install this way, skip the first step of route A and of route B and start from the second.</p>
+      <p class="aside">In VCC that is the Add Repository button on the Packages tab of the Settings page. In ALCOM it is the Add Repository button on the Repositories tab of the Packages page. Once the repository is added, Unity MCP appears in the project's package list. If you install this way, skip the first step of route A and of route B and start from the second.</p>
     </div>
   </section>
 


### PR DESCRIPTION
The English pages sent readers to "the Repositories page under Resources".
ALCOM's sidebar is Projects, Packages & Templates, Settings and Logs;
there is no Resources anywhere in it. Its own English locale calls the
sidebar item Packages and the tab Repositories, so that is what the pages
say now. The Japanese pages were already right.

Checked against ALCOM 1.1.8 running, and against
vrc-get-gui/locales/en.json5 and ja.json5 at gui-v1.1.8 for the exact
labels rather than a translation of the Japanese.

That run also exercised the VPM route end to end for the first time: the
vcc://vpm/addRepo link the guide publishes opens in both VCC and ALCOM and
adds the repository, and the repository arrives enabled.