### PR TITLE
feat: publish to the official MCP registry

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,7 +1,9 @@
 # Unity MCP Integration Framework
 
+<!-- mcp-name: io.github.isuzu-shiranui/unity-mcp -->
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-4.0.5-brightgreen)
+![Version](https://img.shields.io/badge/version-4.0.6-brightgreen)
 ![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
 ![.NET](https://img.shields.io/badge/.NET-10-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unity MCP 統合フレームワーク
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-![Version](https://img.shields.io/badge/version-4.0.5-brightgreen)
+![Version](https://img.shields.io/badge/version-4.0.6-brightgreen)
 ![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
 ![.NET](https://img.shields.io/badge/.NET-10-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.0.5</Version>
+    <Version>4.0.6</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [4.0.6] - 2026-09-08
+
+### Added
+- A `server.json` at the repository root, so this can be published to the official MCP registry.
+  An agent looking for a way to drive Unity searches that registry before it searches the web,
+  and this was not in it. The entry describes the NuGet package as a stdio client, which is what
+  it is: the Editor serves MCP itself, and the CLI bridges a client's stdio to the endpoint the
+  Editor publishes. The registry's `remotes` form does not fit, because it requires a publicly
+  reachable URL and this one is on the loopback interface.
+- The README the NuGet package ships carries an `mcp-name` marker. That is how the registry
+  proves the package and the registry entry belong to the same owner.
+
 ## [4.0.5] - 2026-09-08
 
 ### Fixed

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.0.5";
+        private const string FallbackVersion = "4.0.6";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "Drive the Unity Editor from an AI agent or the terminal. The Editor serves MCP itself, so there is no second process to run, and the isuzu-unity-cli command needs no Node or .NET runtime.",

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "1f509e2af6164316c542954c053b395f793f7fac94169cf538ad9cb368c3e926",
+    "sourceHash":  "4d9d178d462d72e6d7f285707d1020aa7a632b99816375834f2192a11e5bd39d",
     "total":  508,
     "passed":  507,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-08T00:23:53.8720972Z"
+    "ranAt":  "2026-09-08T01:54:39.5701124Z"
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.isuzu-shiranui/unity-mcp",
+  "title": "Unity MCP",
+  "description": "Drive a running Unity Editor from an AI agent. The Editor serves MCP itself over Streamable HTTP on the loopback interface, so there is no second server process; this package is the client that bridges stdio to it. Covers the console, compilation, the scene, assets, prefabs, materials, shaders, Animator Controllers, Timeline, the test runner, play mode, builds and screenshots.",
+  "version": "4.0.6",
+  "repository": {
+    "url": "https://github.com/isuzu-shiranui/UnityMCP",
+    "source": "github"
+  },
+  "websiteUrl": "https://unity-mcp.shiranui-isuzu.dev/en/",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "identifier": "IsuzuUnityCli",
+      "version": "4.0.6",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "UNITY_MCP_STATE_DIR",
+          "description": "Where the Editor writes its descriptors. Set this only when the default location cannot be reached, such as from WSL.",
+          "format": "string",
+          "isRequired": false
+        },
+        {
+          "name": "UNITY_MCP_HOST",
+          "description": "Replaces 127.0.0.1 in the descriptor endpoint, for reaching an Editor on the Windows host from WSL.",
+          "format": "string",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
An agent looking for a way to drive Unity searches the MCP registry before
it searches the web. Querying that registry for "unity" returns entries
from several other projects and nothing from this one, so the way most
agents would find this simply did not exist.

server.json describes the NuGet package as a stdio client, which is what
it is: the Editor serves MCP itself over Streamable HTTP, and
`isuzu-unity-cli mcp-stdio` bridges a client's stdio to the endpoint it
publishes. The registry's `remotes` form requires a publicly reachable
URL, so it does not fit an endpoint on the loopback interface.

The README the NuGet package ships carries an mcp-name marker, which is
how the registry proves the package and the entry share an owner.
Confirmed by packing 4.0.6 and reading the marker back out of the
generated .nupkg rather than assuming the README reached it.

Verified: EditMode 508 (507 passed, 1 GUI-only skipped) with the
attestation regenerated; CLI 214 tests.