### PR TITLE
A hierarchy read that costs a fifth, and one that costs nothing twice

### DIFF
--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -22,7 +22,7 @@ The idempotency column says only whether a call may be retried automatically aft
 | `compile_request` | unsafe | Ask for a recompile. Runs a full asset refresh first, which imports changed assets and can open a modal dialog |
 | `test_run` | unsafe | Start an EditMode or PlayMode test run |
 | `test_results` | safe | The current or most recent run (readable while it runs) |
-| `scene_browse_hierarchy` | safe | Walk the hierarchy. Emits `path`, which every editing tool takes. A filtered walk also returns the parents leading down to each match. `missing_scripts: true` returns only objects carrying a component whose script cannot be resolved, and `missingScripts` on each object counts them |
+| `scene_browse_hierarchy` | safe | Walk the hierarchy. Emits `path`, which every editing tool takes. A filtered walk also returns the parents leading down to each match. `missing_scripts: true` returns only objects carrying a component whose script cannot be resolved, and `missingScripts` on each object counts them. A key missing from a node is at its default: active true, tag Untagged, layer Default, no missing scripts. Every reply carries a `snapshotId`; pass one back as `since` and the reply is what differs from that state instead of the tree |
 | `scene_list` | safe | Open scenes, and the scenes in the build settings |
 | `inspect_read` | safe | Read a serialized property. Omit `component_type` to address the GameObject itself |
 | `inspect_list` | safe | Discover property paths. Omit `component_type` to address the GameObject itself |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -22,7 +22,7 @@ Editor が公開する 88 個のツールを、グループごとの表で説明
 | `compile_request` | unsafe | 再コンパイルを要求。先にアセットの完全なリフレッシュが実行されるので、変更されたアセットのインポートが起きます。モーダルダイアログが開くこともあります |
 | `test_run` | unsafe | EditMode / PlayMode テストの実行を開始 |
 | `test_results` | safe | 実行中・直近のテスト結果（実行中でも読める） |
-| `scene_browse_hierarchy` | safe | シーン階層の走査。`path` を返すので編集系にそのまま渡せます。絞り込んでも、一致したオブジェクトへ至る親は結果に含まれます。`missing_scripts: true` は、スクリプトが解決できないコンポーネントを持つオブジェクトだけを返します。各オブジェクトの `missingScripts` が、その件数です |
+| `scene_browse_hierarchy` | safe | シーン階層の走査。`path` を返すので編集系にそのまま渡せます。絞り込んでも、一致したオブジェクトへ至る親は結果に含まれます。`missing_scripts: true` は、スクリプトが解決できないコンポーネントを持つオブジェクトだけを返します。各オブジェクトの `missingScripts` が、その件数です。ノードに無いキーは既定値です（active は true、tag は Untagged、layer は Default、欠けたスクリプトなし）。応答は必ず `snapshotId` を返し、それを `since` に渡すと木の代わりにその状態との差分が返ります |
 | `scene_list` | safe | 開いているシーンとビルド設定のシーン |
 | `inspect_read` | safe | シリアライズプロパティの読み取り。`component_type` を省くと GameObject 自身が対象です |
 | `inspect_list` | safe | シリアライズプロパティの一覧。`component_type` を省くと GameObject 自身が対象です |

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Cli/ArgParser.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Cli/ArgParser.cs
@@ -21,7 +21,17 @@ public static class ArgParser
     public static readonly IReadOnlySet<string> CliOnlyOptions = new HashSet<string>(StringComparer.Ordinal)
     {
         "json", "project", "file", "raw", "help", "agent", "client", "yes", "no-skill", "mcp", "scope", "fix", "version",
-        "group",
+        "group", "compact",
+    };
+
+    /// <summary>
+    /// Options that are on or off. Without this the parser takes whatever follows as the value,
+    /// so <c>--compact projects</c> loses the command and <c>call --compact scene_browse_hierarchy</c>
+    /// loses the tool name, and neither reads as set.
+    /// </summary>
+    private static readonly IReadOnlySet<string> ValuelessOptions = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "compact", "raw", "help", "version", "yes", "no-skill", "fix",
     };
 
     public static ParsedArgs Parse(IReadOnlyList<string> argv)
@@ -49,7 +59,8 @@ public static class ArgParser
             var name = token.Substring(2);
             var next = i + 1 < argv.Count ? argv[i + 1] : null;
 
-            if (next is null || next.StartsWith("--", StringComparison.Ordinal))
+            if (next is null || next.StartsWith("--", StringComparison.Ordinal)
+                || ValuelessOptions.Contains(name))
             {
                 AddFlag(flags, name);
             }

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Cli/JsonOutput.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Cli/JsonOutput.cs
@@ -8,13 +8,21 @@ namespace IsuzuUnityCli.Cli;
 public static class JsonOutput
 {
     // The default encoder escapes every non-ASCII character, which turns Japanese tool output into \uXXXX noise.
-    private static readonly JsonWriterOptions WriterOptions = new()
+    private static readonly JsonWriterOptions Pretty = new()
     {
         Indented = true,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 
-    public static string Format(JsonNode? node)
+    // Indentation is most of a large response: a 523-object scene prints as 346 KB indented and
+    // 124 KB packed, and whatever reads it pays for the whitespace.
+    private static readonly JsonWriterOptions Packed = new()
+    {
+        Indented = false,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    public static string Format(JsonNode? node, bool indented)
     {
         if (node is null)
         {
@@ -22,7 +30,7 @@ public static class JsonOutput
         }
 
         using var buffer = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(buffer, WriterOptions))
+        using (var writer = new Utf8JsonWriter(buffer, indented ? Pretty : Packed))
         {
             node.WriteTo(writer);
         }
@@ -30,8 +38,8 @@ public static class JsonOutput
         return Encoding.UTF8.GetString(buffer.ToArray());
     }
 
-    public static void Print(TextWriter output, JsonNode? node)
+    public static void Print(TextWriter output, JsonNode? node, bool indented)
     {
-        output.WriteLine(Format(node));
+        output.WriteLine(Format(node, indented));
     }
 }

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Cli/Usage.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Cli/Usage.cs
@@ -34,6 +34,9 @@ public static class Usage
                                          Either the product name or the project folder the
                                          window title shows; a unique part of either will do
           --raw                          Print the response envelope instead of just the result
+          --compact                      Print JSON without indentation. Already the default when
+                                         output is piped or redirected, which is how an agent
+                                         reads it; this forces it in a terminal too
           --version                      Show the version
           -h, --help                     Show this help
 

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/CommandContext.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/CommandContext.cs
@@ -28,6 +28,13 @@ public sealed class CommandContext
     public UnityHttpClient Client { get; init; } = new();
     public CancellationToken Cancellation { get; init; }
 
+    /// <summary>
+    /// Whether printed JSON is indented. Stated rather than sensed: <see cref="Out"/> is
+    /// substitutable, so reading the process's own stdout here would describe a writer this
+    /// context may not be using. <c>Program.Main</c> decides it once from the real stdout.
+    /// </summary>
+    public bool Indented { get; init; }
+
     public InstanceDescriptor ResolveInstance(ParsedArgs parsed)
     {
         return InstanceResolver.Resolve(ReadDescriptors(), parsed.Option("project"), WorkingDirectory);
@@ -42,7 +49,7 @@ public sealed class CommandContext
     {
         if (raw)
         {
-            JsonOutput.Print(Out, envelope.Raw);
+            JsonOutput.Print(Out, envelope.Raw, Indented);
             ReportRunning(envelope);
             return envelope.IsError ? 1 : 0;
         }
@@ -53,7 +60,7 @@ public sealed class CommandContext
             return 1;
         }
 
-        JsonOutput.Print(Out, envelope.Result);
+        JsonOutput.Print(Out, envelope.Result, Indented);
         ReportRunning(envelope);
         return 0;
     }

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/ProjectsCommand.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/ProjectsCommand.cs
@@ -43,7 +43,7 @@ public static class ProjectsCommand
             ContainsWorkingDirectory = here is not null && ReferenceEquals(here, d),
         }).ToList();
 
-        JsonOutput.Print(context.Out, JsonSerializer.SerializeToNode(rows, CliJsonContext.Default.ListProjectRow));
+        JsonOutput.Print(context.Out, JsonSerializer.SerializeToNode(rows, CliJsonContext.Default.ListProjectRow), context.Indented);
         return 0;
     }
 }

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/VerifyCommand.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/VerifyCommand.cs
@@ -61,7 +61,7 @@ public static class VerifyCommand
 
         if (parsed.HasFlag("raw"))
         {
-            JsonOutput.Print(context.Out, run.Summary(startedAt, elapsed.Elapsed));
+            JsonOutput.Print(context.Out, run.Summary(startedAt, elapsed.Elapsed), context.Indented);
         }
         else
         {

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.0.6</Version>
+    <Version>4.1.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Program.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Program.cs
@@ -20,7 +20,12 @@ public static class Program
             cts.Cancel();
         };
 
-        var context = new CommandContext { Cancellation = cts.Token };
+        // A terminal gets indentation because a person is reading it; a pipe or a redirect,
+        // which is how an agent reads it, gets the packed form. --compact forces packed anywhere.
+        var indented = !Console.IsOutputRedirected
+            && !ArgParser.Parse(argv).HasFlag("compact");
+
+        var context = new CommandContext { Cancellation = cts.Token, Indented = indented };
         return await Run(argv, context);
     }
 

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/ArgParserTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/ArgParserTests.cs
@@ -47,4 +47,30 @@ public sealed class ArgParserTests
         Assert.True(ArgParser.Parse(["-h"]).HasFlag("help"));
         Assert.True(ArgParser.Parse(["call", "--help"]).HasFlag("help"));
     }
+
+    [Theory]
+    [InlineData(new[] { "--compact", "projects" }, "projects")]
+    [InlineData(new[] { "projects", "--compact" }, "projects")]
+    [InlineData(new[] { "--compact", "call", "scene_browse_hierarchy" }, "call")]
+    [InlineData(new[] { "call", "--compact", "scene_browse_hierarchy" }, "call")]
+    [InlineData(new[] { "call", "scene_browse_hierarchy", "--compact" }, "call")]
+    public void AValuelessOptionIsAFlagWhereverItSits(string[] argv, string command)
+    {
+        // Taking the next token as a value loses the command or the tool name, and the flag
+        // then reads as unset: the caller gets indented output and a puzzling error.
+        var parsed = ArgParser.Parse(argv);
+
+        Assert.True(parsed.HasFlag("compact"));
+        Assert.Equal(command, parsed.Command);
+    }
+
+    [Fact]
+    public void AnOptionThatTakesAValueStillTakesTheNextToken()
+    {
+        var parsed = ArgParser.Parse(["call", "scene_browse_hierarchy", "--json", "{\"limit\":5}", "--compact"]);
+
+        Assert.Equal("{\"limit\":5}", parsed.Option("json"));
+        Assert.True(parsed.HasFlag("compact"));
+        Assert.Equal("scene_browse_hierarchy", parsed.Positional[0]);
+    }
 }

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/CommandContextTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/CommandContextTests.cs
@@ -11,11 +11,13 @@ public sealed class CommandContextTests
          "message":"'execute_code' is still running on the Editor main thread. The Editor is showing a dialog \"MCP probe\" (Pick one) with buttons Yes / No."}}
         """;
 
-    private static (CommandContext Context, StringWriter Out, StringWriter Err) Context()
+    // Indentation is stated rather than inherited: its default reads Console.IsOutputRedirected,
+    // which depends on how the test host was started.
+    private static (CommandContext Context, StringWriter Out, StringWriter Err) Context(bool indented = true)
     {
         var output = new StringWriter();
         var error = new StringWriter();
-        return (new CommandContext { Out = output, Err = error }, output, error);
+        return (new CommandContext { Out = output, Err = error, Indented = indented }, output, error);
     }
 
     [Fact]
@@ -27,6 +29,20 @@ public sealed class CommandContextTests
 
         Assert.Contains("\"jobId\": \"execute_code-3\"", output.ToString());
         Assert.Contains("showing a dialog \"MCP probe\"", error.ToString());
+    }
+
+    [Fact]
+    public void PackedOutputCarriesTheSameFieldsWithoutTheWhitespace()
+    {
+        var (indented, prettyOut, _) = Context();
+        var (packed, packedOut, _) = Context(indented: false);
+
+        indented.Report(Envelope.Parse(202, Running), raw: false);
+        packed.Report(Envelope.Parse(202, Running), raw: false);
+
+        Assert.Contains("\"jobId\":\"execute_code-3\"", packedOut.ToString());
+        Assert.DoesNotContain("\"jobId\": ", packedOut.ToString());
+        Assert.True(packedOut.ToString().Length < prettyOut.ToString().Length);
     }
 
     [Fact]

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/UnityHttpClientTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/UnityHttpClientTests.cs
@@ -121,6 +121,9 @@ public sealed class UnityHttpClientTests
             Client = Client(),
             ReadDescriptors = () => [server.Descriptor()],
             WorkingDirectory = Path.GetTempPath(),
+            // The assertion below is on the indented form. The default reads
+            // Console.IsOutputRedirected, which is true under the test host.
+            Indented = true,
         };
 
         var code = await CallCommand.Run(ArgParser.Parse(["call", "build_player", "--target", "StandaloneWindows64"]), context);

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## [4.1.0] - 2026-09-09
+
+### Breaking
+- A `scene_browse_hierarchy` node no longer carries `id`. It held the same value as `instanceId`,
+  written from the same expression, and every other tool emits only `instanceId`. Read
+  `instanceId`; a `fields` allowlist naming `id` now selects nothing.
+- A node leaves out any key sitting at its default — `active` true, `tag` Untagged, `layer`
+  Default, `missingScripts` zero. On a scene of 523 objects those four were 24 KB of a reply that
+  said nothing by carrying them. In a reply that was not narrowed by `fields`, a missing key is
+  at its default; under an allowlist it is missing because it was not asked for, and the two
+  readings do not mix. Code that reads `node["tag"]` unconditionally, or deserialises into a
+  type whose `Active` defaults to false, has to change.
+- The CLI no longer indents JSON when its output is piped or redirected. Indentation was 2.8x
+  the bytes of a large reply and whatever reads it pays for the whitespace: a 523-object
+  hierarchy printed as 346 KB where the same content packs into 124 KB. A terminal still gets
+  indentation, because a person is reading it, and `--compact` forces the packed form there too.
+  Anything parsing the CLI's output as JSON is unaffected; anything matching its text is not.
+
+  Together the three take a 523-object hierarchy from 346 KB to 74 KB, and from 87,563 tokens
+  to 38,975.
+
+### Added
+- Every `scene_browse_hierarchy` reply carries a `snapshotId` naming the state it describes, and
+  `since` takes one back: the reply is then what differs from that state — added, changed and
+  removed, flat rather than nested, with a count of the rest. An unchanged scene answers in
+  107 bytes where the full tree takes 84 KB.
+
+  The caller holds its own place. A snapshot is never consumed and never moves, so a second
+  client reading the same scene cannot swallow the changes the first is waiting for, and a reply
+  that never arrives leaves the last id usable — the retry reports the same difference rather
+  than nothing. Objects are followed by instance id, so a rename reads as one change instead of
+  a removal and an addition.
+
+  `removed` names what left this result, which is not the same as destroyed: renaming an object
+  out of a name filter, deactivating one under `active_only`, or moving one past `max_depth` all
+  put it there while it sits in the scene. A node in `changed` replaces the one held under that
+  id rather than merging into it, because a key it does not carry is at its default.
+
+  Refused rather than answered wrongly: a snapshot compared against different filters (everything
+  the narrower walk leaves out would read as removed), a diff with `limit` or `offset` (a window
+  cannot be diffed), and a snapshot the Editor no longer holds. A `fields` allowlist always keeps
+  `instanceId`, because the comparison is built on it.
+- A node carries `siblingIndex`. A path carries an index only where a sibling name repeats, so
+  without it swapping two differently-named siblings changed nothing any reader could see — and
+  sibling order decides draw order under a Canvas.
+- A node in a diff carries `parentInstanceId` and `scene`. A diff arrives flat, so the two things
+  a tree states by its shape have to be on the node instead; without them a root moving between
+  two open scenes read as unchanged. A nested reply leaves both out, because `scenes` groups by
+  scene and `children` names the parent.
+- `--compact` on the CLI prints JSON without indentation, for a terminal.
+
+### Fixed
+- An option that takes no value no longer swallows the token after it. `--compact projects` lost
+  the command and `call --compact <tool>` lost the tool name, and in both the flag then read as
+  unset. `--raw`, `--yes`, `--fix`, `--no-skill`, `--help` and `--version` had the same trap.
+
 ## [4.0.6] - 2026-09-08
 
 ### Added

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.0.6";
+        private const string FallbackVersion = "4.1.0";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/SceneHierarchyBaseline.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/SceneHierarchyBaseline.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+
+using Newtonsoft.Json.Linq;
+
+namespace UnityMCP.Editor.Core
+{
+    /// <summary>
+    /// The states <c>scene_browse_hierarchy</c> has described, each under an id the caller keeps.
+    /// </summary>
+    /// <remarks>
+    /// A snapshot is never consumed and never advances on its own. Two clients browsing the same
+    /// scene hold two ids and each diffs against what it was actually given, so neither can eat
+    /// the other's changes; a reply that never arrives leaves the caller on the id it already
+    /// had, and the retry reports the same difference rather than nothing.
+    /// <para>
+    /// Static and unserialised, so the store empties on a domain reload — which is also when the
+    /// instance ids it is keyed by stop naming the same objects.
+    /// </para>
+    /// </remarks>
+    internal static class SceneHierarchyBaseline
+    {
+        private sealed class Snapshot
+        {
+            public string Walk;
+            public Dictionary<string, string> Nodes;
+        }
+
+        private static readonly Dictionary<string, Snapshot> Snapshots =
+            new Dictionary<string, Snapshot>(StringComparer.Ordinal);
+
+        /// <summary>Most recently used first, so the oldest snapshot is the one dropped.</summary>
+        private static readonly List<string> Recent = new List<string>();
+
+        /// <summary>
+        /// Each snapshot of a large scene is on the order of 70 KB of strings, and one is taken
+        /// per call rather than per filter, so the ceiling is what bounds the store.
+        /// </summary>
+        private const int KeepAtMost = 16;
+
+        private static long counter;
+
+        private static readonly object Gate = new object();
+
+        internal sealed class Diff
+        {
+            public JArray Added { get; set; }
+            public JArray Changed { get; set; }
+            public JArray Removed { get; set; }
+            public int Unchanged { get; set; }
+        }
+
+        /// <summary>Records what was returned and names it, without comparing it to anything.</summary>
+        public static string Remember(string walk, IReadOnlyList<JObject> nodes)
+        {
+            var state = Serialise(nodes);
+
+            lock (Gate)
+            {
+                counter++;
+                var id = "snap-" + counter.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                Snapshots[id] = new Snapshot { Walk = walk, Nodes = state };
+                Touch(id);
+                return id;
+            }
+        }
+
+        /// <summary>The walk a snapshot describes, or null when it is gone.</summary>
+        public static string WalkOf(string id)
+        {
+            lock (Gate)
+            {
+                return Snapshots.TryGetValue(id, out var snapshot) ? snapshot.Walk : null;
+            }
+        }
+
+        /// <summary>
+        /// Compares against the snapshot the caller names and records the new state under a new
+        /// id. Returns null when that snapshot is gone, which the caller has to answer by
+        /// reading in full again.
+        /// </summary>
+        public static Diff CompareWith(string sinceId, string walk, IReadOnlyList<JObject> nodes, out string newId)
+        {
+            var state = Serialise(nodes);
+
+            lock (Gate)
+            {
+                if (!Snapshots.TryGetValue(sinceId, out var snapshot))
+                {
+                    newId = null;
+                    return null;
+                }
+
+                var previous = snapshot.Nodes;
+
+                var diff = new Diff
+                {
+                    Added = new JArray(),
+                    Changed = new JArray(),
+                    Removed = new JArray(),
+                };
+
+                foreach (var node in nodes)
+                {
+                    var id = IdOf(node);
+                    if (id == null)
+                    {
+                        continue;
+                    }
+
+                    if (!previous.TryGetValue(id, out var before))
+                    {
+                        diff.Added.Add(node);
+                    }
+                    else if (!string.Equals(before, state[id], StringComparison.Ordinal))
+                    {
+                        diff.Changed.Add(node);
+                    }
+                    else
+                    {
+                        diff.Unchanged++;
+                    }
+                }
+
+                foreach (var pair in previous)
+                {
+                    if (!state.ContainsKey(pair.Key))
+                    {
+                        // The same spelling the nodes use: a number before Unity 6.5 and a string
+                        // from 6.5 on. A caller keying by the id it was given has to be able to
+                        // find the removal with it.
+                        diff.Removed.Add(EntityIdCompat.Wire(long.Parse(
+                            pair.Key, System.Globalization.CultureInfo.InvariantCulture)));
+                    }
+                }
+
+                counter++;
+                newId = "snap-" + counter.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                Snapshots[newId] = new Snapshot { Walk = walk, Nodes = state };
+                Touch(sinceId);
+                Touch(newId);
+                return diff;
+            }
+        }
+
+        /// <summary>Empties the store. For tests, which need each to start from nothing.</summary>
+        internal static void Reset()
+        {
+            lock (Gate)
+            {
+                Snapshots.Clear();
+                Recent.Clear();
+                counter = 0;
+            }
+        }
+
+        private static string IdOf(JObject node)
+        {
+            var token = node["instanceId"];
+            if (token == null || token.Type == JTokenType.Null)
+            {
+                return null;
+            }
+
+            var text = token.ToString();
+            return text.Length == 0 ? null : text;
+        }
+
+        private static Dictionary<string, string> Serialise(IReadOnlyList<JObject> nodes)
+        {
+            var state = new Dictionary<string, string>(nodes.Count, StringComparer.Ordinal);
+
+            foreach (var node in nodes)
+            {
+                var id = IdOf(node);
+                if (id != null)
+                {
+                    state[id] = node.ToString(Newtonsoft.Json.Formatting.None);
+                }
+            }
+
+            return state;
+        }
+
+        private static void Touch(string id)
+        {
+            Recent.Remove(id);
+            Recent.Insert(0, id);
+
+            while (Recent.Count > KeepAtMost)
+            {
+                var oldest = Recent[Recent.Count - 1];
+                Recent.RemoveAt(Recent.Count - 1);
+                Snapshots.Remove(oldest);
+            }
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/SceneHierarchyBaseline.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/SceneHierarchyBaseline.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e0e0d61edb7654145864ce5be661c1e9

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/SceneHierarchy.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/SceneHierarchy.cs
@@ -30,6 +30,51 @@ namespace UnityMCP.Editor.Handlers
                 var offset = Math.Max(0, parameters["offset"]?.Value<int>() ?? 0);
                 var fieldsFilter = ListResponseBuilder.ParseFieldsParam(parameters["fields"]?.ToString());
 
+                var since = parameters["since"]?.ToString();
+                var diffing = !string.IsNullOrEmpty(since);
+
+                // Identity is what a diff is built on, and every reply is one a later call can
+                // diff against, so the allowlist never drops it. Left out, each node would fail
+                // to match itself and the comparison would report a still scene however much
+                // had moved.
+                if (fieldsFilter != null && fieldsFilter.Length > 0
+                    && Array.IndexOf(fieldsFilter, "instanceId") < 0)
+                {
+                    var widened = new string[fieldsFilter.Length + 1];
+                    Array.Copy(fieldsFilter, widened, fieldsFilter.Length);
+                    widened[fieldsFilter.Length] = "instanceId";
+                    fieldsFilter = widened;
+                }
+
+                // Two different walks describe two different sets of objects. Comparing across
+                // them reports everything the narrower one leaves out as removed, which is a
+                // confident wrong answer about objects that are still in the scene.
+                var walk = WalkOf(nameFilter, componentFilter, tagFilter, maxDepth,
+                    activeOnly, missingScriptsOnly, sceneIndex, fieldsFilter);
+
+                if (diffing)
+                {
+                    var takenUnder = SceneHierarchyBaseline.WalkOf(since);
+                    if (takenUnder != null && !string.Equals(takenUnder, walk, StringComparison.Ordinal))
+                    {
+                        return new JObject
+                        {
+                            ["error"] = $"snapshot '{since}' was taken with different arguments ({takenUnder}); ask for the difference with the same ones, or read without 'since' to take a new snapshot"
+                        };
+                    }
+                }
+
+                // A window over the traversal cannot be diffed. The snapshot would hold one page
+                // and the next call another, so an object pushed out of the window by an earlier
+                // insertion would be reported as removed while it is still there.
+                if (diffing && (limit > 0 || offset > 0))
+                {
+                    return new JObject
+                    {
+                        ["error"] = "'since' covers the whole filtered set and cannot be paged; drop limit and offset, or narrow with a filter instead"
+                    };
+                }
+
                 var hasFilter = !string.IsNullOrEmpty(nameFilter)
                     || !string.IsNullOrEmpty(componentFilter)
                     || !string.IsNullOrEmpty(tagFilter)
@@ -80,13 +125,37 @@ namespace UnityMCP.Editor.Handlers
                 // 2. Apply offset/limit and project to JObjects via ListResponseBuilder.
                 var total = flat.Count;
                 var effectiveLimit = limit <= 0 ? int.MaxValue : limit;
-                var page = ListResponseBuilder.Build(
-                    flat,
-                    offset,
-                    effectiveLimit,
-                    ProjectFlatNode,
-                    fieldsFilter
-                );
+                JObject page;
+                projecting = flat;
+                try
+                {
+                    page = ListResponseBuilder.Build(
+                        flat,
+                        offset,
+                        effectiveLimit,
+                        ProjectFlatNode,
+                        fieldsFilter
+                    );
+                }
+                finally
+                {
+                    projecting = null;
+                }
+
+                if (diffing)
+                {
+                    return Changes(since, walk, page, total);
+                }
+
+                // A snapshot of what is about to be described, named so the next call can ask
+                // for the difference from it. Taken before the page is re-nested, because the
+                // rebuild moves the nodes into the tree, and before the two keys below are
+                // dropped, because a comparison has to see everything that can change.
+                var snapshotId = SceneHierarchyBaseline.Remember(walk, Peek(page));
+
+                // The tree says both of these already: `scenes` groups by scene and `children`
+                // names the parent. Carried per node they were 40% of the response.
+                DropWhatTheTreeAlreadySays(page);
 
                 // 3. Rebuild the scenes[] structure from the page, preserving
                 //    parent→children where both ends survived the paging window.
@@ -94,6 +163,7 @@ namespace UnityMCP.Editor.Handlers
 
                 var result = new JObject
                 {
+                    ["snapshotId"] = snapshotId,
                     ["scenes"] = scenes,
                     ["sceneCount"] = endIndex - startIndex,
                     ["total"] = total,
@@ -109,6 +179,114 @@ namespace UnityMCP.Editor.Handlers
             {
                 return new JObject { ["error"] = $"Failed to browse scene hierarchy: {e.Message}" };
             }
+        }
+
+        /// <summary>
+        /// The page as a diff against the snapshot the caller named. Flat rather than nested: a
+        /// diff is a list of what moved, and nesting it would carry back the parents that did
+        /// not move, which is the cost this mode exists to avoid.
+        /// </summary>
+        private static JObject Changes(string since, string walk, JObject page, int total)
+        {
+            var nodes = Detach(page);
+            var diff = SceneHierarchyBaseline.CompareWith(since, walk, nodes, out var snapshotId);
+
+            if (diff == null)
+            {
+                return new JObject
+                {
+                    ["error"] = $"no snapshot '{since}'. It expired, or the Editor reloaded its scripts since it was taken; read without 'since' to take a new one."
+                };
+            }
+
+            return new JObject
+            {
+                ["snapshotId"] = snapshotId,
+                ["since"] = since,
+                ["added"] = diff.Added,
+                ["changed"] = diff.Changed,
+                ["removed"] = diff.Removed,
+                ["unchanged"] = diff.Unchanged,
+                ["total"] = total,
+                ["truncated"] = page["truncated"],
+                ["next"] = page["next"],
+            };
+        }
+
+        /// <summary>
+        /// What a snapshot covers, so a later call can be told it is asking about a different
+        /// set of objects rather than being handed a diff between two of them.
+        /// </summary>
+        private static string WalkOf(
+            string name, string component, string tag, int maxDepth,
+            bool activeOnly, bool missingScriptsOnly, int? sceneIndex, string[] fields)
+        {
+            var joined = fields == null ? string.Empty : string.Join(",", fields);
+            return $"name={name}|component={component}|tag={tag}|maxDepth={maxDepth}" +
+                   $"|activeOnly={activeOnly}|missingScripts={missingScriptsOnly}" +
+                   $"|sceneIndex={sceneIndex}|fields={joined}";
+        }
+
+        /// <summary>
+        /// Removes the keys a nested reply does not need. They stay in the snapshot, so a later
+        /// diff still notices a root moving between two open scenes or a node changing parent
+        /// without changing its path.
+        /// </summary>
+        private static void DropWhatTheTreeAlreadySays(JObject page)
+        {
+            var items = page["items"] as JArray;
+            if (items == null)
+            {
+                return;
+            }
+
+            foreach (var item in items)
+            {
+                var node = (JObject)item;
+                node.Remove("parentInstanceId");
+                node.Remove("scene");
+            }
+        }
+
+        /// <summary>The page's nodes, left where they are: the tree rebuild still needs them.</summary>
+        private static List<JObject> Peek(JObject page)
+        {
+            var nodes = new List<JObject>();
+            var items = page["items"] as JArray;
+
+            if (items != null)
+            {
+                foreach (var item in items)
+                {
+                    nodes.Add((JObject)item);
+                }
+            }
+
+            return nodes;
+        }
+
+        /// <summary>
+        /// The page's nodes, off the array that owns them. Newtonsoft copies a token that already
+        /// belongs to a container when it is added to a second one, so leaving them parented
+        /// would put copies into the response.
+        /// </summary>
+        private static List<JObject> Detach(JObject page)
+        {
+            var nodes = new List<JObject>();
+            var items = page["items"] as JArray;
+
+            if (items == null)
+            {
+                return nodes;
+            }
+
+            foreach (var item in items)
+            {
+                nodes.Add((JObject)item);
+            }
+
+            items.RemoveAll();
+            return nodes;
         }
 
         private sealed class FlatNode
@@ -166,27 +344,69 @@ namespace UnityMCP.Editor.Handlers
             }
         }
 
+        /// <summary>
+        /// The flat list the current page is being projected from. <see cref="ProjectFlatNode"/>
+        /// needs it to name a node's parent, and the projector signature takes one node.
+        /// </summary>
+        [ThreadStatic]
+        private static List<FlatNode> projecting;
+
         private static JObject ProjectFlatNode(FlatNode n)
         {
             // The nested structure is rebuilt in RebuildScenesFromPage, so we
             // emit only the node-level keys here. ListResponseBuilder applies
             // the `fieldsFilter` allowlist after this projection.
             var go = n.Go;
-            return new JObject
+            var node = new JObject
             {
                 ["name"] = go.name,
                 // The identifier every authoring tool takes. Without it a caller who has just
                 // browsed the hierarchy has to guess at the path of the thing they are looking
                 // at, and guesses fail on any name that repeats among siblings.
                 ["path"] = UnityMCP.Editor.Tools.ObjectResolve.PathOf(go),
-                ["id"] = EntityIdCompat.WireIdOf(go),
                 ["instanceId"] = EntityIdCompat.WireIdOf(go),
-                ["active"] = go.activeSelf,
-                ["tag"] = go.tag,
-                ["layer"] = LayerMask.LayerToName(go.layer),
-                ["components"] = GetComponentNames(go),
-                ["missingScripts"] = MissingScriptCount(go),
+                // A path carries an index only where a sibling name repeats, so without this a
+                // reorder is invisible — and it decides draw order under a Canvas.
+                ["siblingIndex"] = go.transform.GetSiblingIndex(),
+                // A diff arrives flat. Without this the caller can only rebuild the tree by
+                // parsing paths, which is ambiguous when a name contains a slash and says
+                // nothing when a parent is replaced by another of the same name.
+                ["parentInstanceId"] = n.ParentIndex >= 0 && projecting != null
+                    ? EntityIdCompat.WireIdOf(projecting[n.ParentIndex].Go)
+                    : JValue.CreateNull(),
+                // Moving a root from one open scene to another changes nothing else about it.
+                // The path is the stable name; the index shifts as scenes open and close.
+                ["scene"] = SceneManager.GetSceneAt(n.SceneIndex).path,
             };
+
+            // Keys at their default are left out. On a scene of any size they are most of the
+            // response and they carry nothing: a caller reads an absent key as the default.
+            if (!go.activeSelf)
+            {
+                node["active"] = false;
+            }
+
+            if (!string.Equals(go.tag, "Untagged", StringComparison.Ordinal))
+            {
+                node["tag"] = go.tag;
+            }
+
+            var layer = LayerMask.LayerToName(go.layer);
+            if (!string.Equals(layer, "Default", StringComparison.Ordinal))
+            {
+                node["layer"] = layer;
+            }
+
+            // Never empty: every GameObject carries a Transform.
+            node["components"] = GetComponentNames(go);
+
+            var missing = MissingScriptCount(go);
+            if (missing > 0)
+            {
+                node["missingScripts"] = missing;
+            }
+
+            return node;
         }
 
         private static JArray RebuildScenesFromPage(

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/SceneHierarchyTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/SceneHierarchyTests.cs
@@ -27,6 +27,9 @@ namespace UnityMCP.Editor.Tests
         [SetUp]
         public void SetUp()
         {
+            // The baseline outlives a single test, so each one starts from nothing.
+            SceneHierarchyBaseline.Reset();
+
             this.root = new GameObject(RootName);
 
             var childA = new GameObject(ChildAName);
@@ -201,6 +204,302 @@ namespace UnityMCP.Editor.Tests
             Assert.IsNull(childA["path"], "the fields allowlist must still drop unlisted keys");
         }
 
+        private static JObject Full()
+        {
+            return SceneHierarchy.Browse(ToolArgs.Of(("name", NamePrefix)));
+        }
+
+        private static JObject Since(string snapshotId)
+        {
+            return SceneHierarchy.Browse(ToolArgs.Of(("name", NamePrefix), ("since", snapshotId)));
+        }
+
+        private static string SnapshotOf(JObject result)
+        {
+            return result["snapshotId"]?.ToString();
+        }
+
+        private static int Count(JObject result, string key)
+        {
+            return (result[key] as JArray)?.Count ?? -1;
+        }
+
+        [Test]
+        public void EveryReplyNamesTheStateItDescribes()
+        {
+            var full = Full();
+
+            Assert.That(SnapshotOf(full), Is.Not.Null.And.Not.Empty,
+                "without an id the caller has nothing to ask for a difference from");
+        }
+
+        [Test]
+        public void AStillSceneDiffersFromItsOwnSnapshotInNothing()
+        {
+            var result = Since(SnapshotOf(Full()));
+
+            Assert.That(Count(result, "added"), Is.Zero);
+            Assert.That(Count(result, "changed"), Is.Zero);
+            Assert.That(Count(result, "removed"), Is.Zero);
+            Assert.That(result["unchanged"].Value<int>(), Is.EqualTo(result["total"].Value<int>()));
+        }
+
+        [Test]
+        public void OneClientReadingDoesNotConsumeTheChangesAnotherIsWaitingFor()
+        {
+            // The failure this pins: with one baseline per filter, the second read would move the
+            // state the first caller compares against, and it would never hear about the change.
+            var a = SnapshotOf(Full());
+            var b = SnapshotOf(Full());
+
+            var added = new GameObject(NamePrefix + "Shared");
+            try
+            {
+                var forB = Since(b);
+                var forA = Since(a);
+
+                Assert.That(Count(forB, "added"), Is.EqualTo(1), "B has to see it");
+                Assert.That(Count(forA, "added"), Is.EqualTo(1), "and B reading must not eat it for A");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(added);
+            }
+        }
+
+        [Test]
+        public void AReplyThatNeverArrivedLeavesTheOldSnapshotUsable()
+        {
+            // A caller that did not receive an answer retries with the id it still holds, and has
+            // to be told the same difference rather than nothing.
+            var held = SnapshotOf(Full());
+
+            var added = new GameObject(NamePrefix + "Lost");
+            try
+            {
+                var first = Since(held);
+                var retry = Since(held);
+
+                Assert.That(Count(first, "added"), Is.EqualTo(1));
+                Assert.That(Count(retry, "added"), Is.EqualTo(1), "the snapshot must not have moved");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(added);
+            }
+        }
+
+        [Test]
+        public void ASnapshotTheEditorNoLongerHoldsIsAnErrorRatherThanAnEmptyDiff()
+        {
+            var result = Since("snap-does-not-exist");
+
+            Assert.That(result["error"], Is.Not.Null);
+            Assert.That(result["added"], Is.Null, "an empty diff would read as a still scene");
+        }
+
+        [Test]
+        public void ReorderingSiblingsIsAChangeRatherThanNothing()
+        {
+            // A path carries an index only where a sibling name repeats, so without the sibling
+            // index a swap of two differently-named siblings was invisible.
+            var snapshot = SnapshotOf(Full());
+            GameObject.Find(RootName + "/" + ChildBName).transform.SetSiblingIndex(0);
+
+            var result = Since(snapshot);
+
+            Assert.That(Count(result, "changed"), Is.GreaterThan(0), "the reorder has to be reported");
+            Assert.That(Count(result, "removed"), Is.Zero);
+            Assert.That(Count(result, "added"), Is.Zero);
+        }
+
+        [Test]
+        public void ARenameIsOneChangedNodeRatherThanARemovalAndAnAddition()
+        {
+            var snapshot = SnapshotOf(Full());
+
+            // A leaf: renaming a parent rewrites the path of everything under it, and those are
+            // real changes too. This isolates the renamed object itself.
+            GameObject.Find(RootName + "/" + ChildBName).name = ChildBName + "Renamed";
+
+            var result = Since(snapshot);
+
+            // Following objects by path would report this as the old one disappearing and a new
+            // one arriving, which is what instance ids are here to avoid.
+            Assert.That(Count(result, "changed"), Is.EqualTo(1));
+            Assert.That(Count(result, "removed"), Is.Zero);
+            Assert.That(Count(result, "added"), Is.Zero);
+        }
+
+        [Test]
+        public void ADestroyedObjectIsNamedInRemovedTheWayTheNodesNameIt()
+        {
+            var full = Full();
+            var childB = FindByName(ChildrenOf(FindByName(SceneObjects(full), RootName)), ChildBName);
+            var goneId = childB["instanceId"];
+
+            UnityEngine.Object.DestroyImmediate(GameObject.Find(RootName + "/" + ChildBName));
+
+            var result = Since(SnapshotOf(full));
+            var removed = (JArray)result["removed"];
+
+            Assert.That(removed.Count, Is.EqualTo(1));
+            // Same JSON type the nodes carry, so a caller keyed by the id it was given can find
+            // the removal with it. Before Unity 6.5 that is a number, not a string.
+            Assert.That(removed[0].Type, Is.EqualTo(goneId.Type),
+                "removed ids have to be spelled the way node ids are");
+            Assert.That(removed[0].ToString(), Is.EqualTo(goneId.ToString()));
+        }
+
+        [Test]
+        public void AChangedNodeReplacesRatherThanMergesIntoWhatWasHeld()
+        {
+            // A caller applying a shallow merge would keep the old tag and the old active, both
+            // of which are gone from the node precisely because they went back to their default.
+            var childB = GameObject.Find(RootName + "/" + ChildBName);
+            childB.SetActive(false);
+            childB.tag = "Player";
+
+            var snapshot = SnapshotOf(Full());
+            childB.SetActive(true);
+            childB.tag = "Untagged";
+
+            var changed = (JArray)Since(snapshot)["changed"];
+            var node = FindByName(changed, ChildBName);
+
+            Assert.That(node, Is.Not.Null, "going back to the default is still a change");
+            Assert.That(node["active"], Is.Null, "the node carries no active, meaning true");
+            Assert.That(node["tag"], Is.Null, "the node carries no tag, meaning Untagged");
+        }
+
+        [Test]
+        public void RemovedNamesWhatLeftTheResultRatherThanWhatWasDestroyed()
+        {
+            // Renaming an object out of the filter puts it in `removed` while it sits in the
+            // scene. A caller deleting its own record of the object on that word would be wrong.
+            var snapshot = SnapshotOf(Full());
+            var stillThere = GameObject.Find(RootName + "/" + ChildBName);
+            stillThere.name = "OutOfTheFilter";
+
+            try
+            {
+                var result = Since(snapshot);
+
+                Assert.That(Count(result, "removed"), Is.EqualTo(1));
+                Assert.That(stillThere, Is.Not.Null, "and the object is still in the scene");
+                Assert.That(GameObject.Find("/" + RootName + "/OutOfTheFilter"), Is.Not.Null);
+            }
+            finally
+            {
+                stillThere.name = ChildBName;
+            }
+        }
+
+        [Test]
+        public void ADiffCarriesTheParentAndSceneTheTreeWouldHaveShown()
+        {
+            // A diff arrives flat, so the two things the tree says by its shape have to be on
+            // the node instead.
+            var snapshot = SnapshotOf(Full());
+            var added = new GameObject(NamePrefix + "Flat");
+            added.transform.SetParent(this.root.transform);
+
+            try
+            {
+                var node = FindByName((JArray)Since(snapshot)["added"], NamePrefix + "Flat");
+
+                Assert.That(node, Is.Not.Null);
+                Assert.That(node["parentInstanceId"]?.ToString(),
+                    Is.EqualTo(EntityIdCompat.WireIdOf(this.root).ToString()),
+                    "without this the caller can only re-nest by parsing paths");
+                Assert.That(node["scene"], Is.Not.Null,
+                    "a root moving between two open scenes changes nothing else about it");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(added);
+            }
+        }
+
+        [Test]
+        public void TheTreeLeavesOutWhatItsShapeAlreadySays()
+        {
+            // Carried on every node these were 40% of the reply, and the tree states both: the
+            // scene by its grouping, the parent by the nesting.
+            var node = FindByName(SceneObjects(Full()), RootName);
+
+            Assert.That(node["parentInstanceId"], Is.Null);
+            Assert.That(node["scene"], Is.Null);
+        }
+
+        [Test]
+        public void ASnapshotIsNotComparedAgainstADifferentWalk()
+        {
+            // A shallower walk leaves out everything below its depth. Diffed against a deeper
+            // snapshot it would report all of that as removed, naming objects that are still in
+            // the scene — a confident wrong answer rather than an error.
+            var deep = SnapshotOf(SceneHierarchy.Browse(
+                ToolArgs.Of(("name", NamePrefix), ("maxDepth", 12))));
+
+            var result = SceneHierarchy.Browse(ToolArgs.Of(
+                ("name", NamePrefix), ("maxDepth", 1), ("since", deep)));
+
+            Assert.That(result["error"], Is.Not.Null);
+            Assert.That(result["removed"], Is.Null);
+        }
+
+        [Test]
+        public void ASnapshotIsComparedAgainstTheSameWalkWithoutComplaint()
+        {
+            var snapshot = SnapshotOf(SceneHierarchy.Browse(
+                ToolArgs.Of(("name", NamePrefix), ("maxDepth", 12))));
+
+            var result = SceneHierarchy.Browse(ToolArgs.Of(
+                ("name", NamePrefix), ("maxDepth", 12), ("since", snapshot)));
+
+            Assert.That(result["error"], Is.Null);
+            Assert.That(Count(result, "removed"), Is.Zero);
+        }
+
+        [Test]
+        public void APagedDiffIsRefusedRatherThanAnsweredWrongly()
+        {
+            // The snapshot would hold one window and the next call another, so an object pushed
+            // out of the window by an earlier insertion would read as removed while it is still
+            // in the scene.
+            var snapshot = SnapshotOf(Full());
+            var limited = SceneHierarchy.Browse(ToolArgs.Of(("since", snapshot), ("limit", 10)));
+            var skipped = SceneHierarchy.Browse(ToolArgs.Of(("since", snapshot), ("offset", 5)));
+
+            Assert.That(limited["error"], Is.Not.Null);
+            Assert.That(skipped["error"], Is.Not.Null);
+            Assert.That(limited["added"], Is.Null);
+        }
+
+        [Test]
+        public void AFieldsAllowlistCannotDropTheKeyTheDiffIsBuiltOn()
+        {
+            // Without instanceId every node fails to match itself, and the call reports a still
+            // scene however much moved.
+            var snapshot = SnapshotOf(SceneHierarchy.Browse(
+                ToolArgs.Of(("name", NamePrefix), ("fields", "name"))));
+
+            var added = new GameObject(NamePrefix + "Added");
+            try
+            {
+                var result = SceneHierarchy.Browse(ToolArgs.Of(
+                    ("name", NamePrefix), ("since", snapshot), ("fields", "name")));
+
+                Assert.That(Count(result, "added"), Is.EqualTo(1), "the new object has to be seen");
+                Assert.That(((JArray)result["added"])[0]["instanceId"], Is.Not.Null,
+                    "instanceId is kept even though the allowlist did not name it");
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(added);
+            }
+        }
+
         private static int ActiveSceneIndex()
         {
             var active = SceneManager.GetActiveScene();
@@ -217,18 +516,34 @@ namespace UnityMCP.Editor.Tests
         }
 
         [Test]
-        public void EveryObjectReportsHowManyOfItsComponentsLostTheirScript()
+        public void AnObjectWhoseScriptsAllResolveSaysSoByLeavingTheCountOut()
         {
             // A missing script cannot be synthesised in a test: it needs a serialised reference to
-            // a type the domain no longer has. What can be pinned is that the count is reported and
-            // reads zero for objects whose components all resolve, so a caller can trust the field
-            // rather than inferring absence from a name it has to match.
+            // a type the domain no longer has. What can be pinned is the reading of an absent key,
+            // which is what the description promises: no `missingScripts` means none are missing.
             var result = SceneHierarchy.Browse(ToolArgs.Of(("name", NamePrefix)));
             var nodes = SceneObjects(result);
             var node = FindByName(nodes, RootName);
 
-            Assert.That(node["missingScripts"], Is.Not.Null, "the field has to be present to be trusted");
-            Assert.That(node["missingScripts"].Value<int>(), Is.Zero);
+            Assert.That(node["missingScripts"], Is.Null, "a zero count is carried by the key's absence");
+        }
+
+        [Test]
+        public void KeysSittingAtTheirDefaultAreLeftOutOfEveryNode()
+        {
+            // These four are the bulk of a large response and say nothing. The contract is that a
+            // caller reads their absence as the default, so a node built from an untouched
+            // GameObject has to carry none of them.
+            var result = SceneHierarchy.Browse(ToolArgs.Of(("name", NamePrefix)));
+            var node = FindByName(SceneObjects(result), RootName);
+
+            Assert.That(node["active"], Is.Null, "active true is the default");
+            Assert.That(node["tag"], Is.Null, "Untagged is the default");
+            Assert.That(node["layer"], Is.Null, "Default is the default layer");
+            Assert.That(node["name"], Is.Not.Null, "name is never dropped");
+            Assert.That(node["path"], Is.Not.Null, "path is never dropped");
+            Assert.That(node["instanceId"], Is.Not.Null, "instanceId is never dropped");
+            Assert.That(node["id"], Is.Null, "id duplicated instanceId and is gone");
         }
 
         [Test]

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/SceneTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/SceneTools.cs
@@ -27,7 +27,14 @@ namespace UnityMCP.Editor.Tools
             "include objects that do not themselves satisfy the filter. While a prefab is open for " +
             "editing this still reports the scene behind it, and paths from that scene cannot be " +
             "resolved by the gameobject_ and inspect_ tools, which address the prefab contents " +
-            "instead.",
+            "instead. In a reply that was not narrowed by 'fields', a key missing from a node " +
+            "is at its default: active true, tag Untagged, layer Default, no missing " +
+            "scripts. Under a 'fields' allowlist a key is missing because it was not " +
+            "asked for, and says nothing about the object — the two readings do not mix, " +
+            "so do not fold a narrowed reply into a cache of full ones. The allowlist " +
+            "always keeps 'instanceId', because every reply is a state a later call can " +
+            "ask the difference from. Every reply carries a 'snapshotId' naming the state " +
+            "it describes, which 'since' takes to ask for a difference instead of a tree.",
             Idempotency = McpIdempotency.Safe,
             // Produces the object paths every other tool takes as an argument, so it is needed
             // before most of them rather than instead of them.
@@ -61,7 +68,32 @@ namespace UnityMCP.Editor.Tools
             [McpArg("offset", "Entries to skip, for paging.")]
             int offset = 0,
             [McpArg("fields", "Comma-separated field whitelist, to keep responses small.")]
-            string fields = null)
+            string fields = null,
+            [McpArg("since", "A 'snapshotId' from an earlier call. Given one, the reply is what " +
+                             "differs from that state — added, changed and removed, flat rather " +
+                             "than nested, with a count of the rest — instead of the tree. " +
+                             "Objects are followed by instance id, so a rename reads as one " +
+                             "change rather than a removal and an addition. Every reply carries " +
+                             "its own 'snapshotId', including this one, so a caller holds its " +
+                             "own place and nobody else's call moves it; a reply that never " +
+                             "arrives leaves the last id usable. It covers the whole filtered " +
+                             "set, so 'limit' and 'offset' are refused with it. A " +
+                             "snapshot the Editor no longer holds is an error asking for a " +
+                             "fresh read; it does not survive the Editor reloading its scripts. " +
+                             "Ask with the same filters the snapshot was taken under: comparing " +
+                             "across two different walks is refused, because everything the " +
+                             "narrower one leaves out would otherwise read as removed. " +
+                             "'removed' names what left this result, which is not the same " +
+                             "as destroyed: renaming an object out of a name filter, " +
+                             "deactivating one under 'active_only', or moving one past " +
+                             "'max_depth' all put it there while it sits in the scene. A " +
+                             "node in 'changed' replaces the one held under that id rather " +
+                             "than merging into it: a key it does not carry is at its " +
+                             "default, so merging would keep a stale 'active' or 'tag' " +
+                             "that has since gone back to normal. 'unchanged' counts nodes " +
+                             "identical in the fields this reply carries, not objects " +
+                             "nothing happened to.")]
+            string since = null)
         {
             return SceneHierarchy.Browse(ToolArgs.Of(
                 ("name", name),
@@ -73,7 +105,8 @@ namespace UnityMCP.Editor.Tools
                 ("sceneIndex", sceneIndex),
                 ("limit", limit),
                 ("offset", offset),
-                ("fields", fields)));
+                ("fields", fields),
+                ("since", since)));
         }
 
         [McpTool(

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "Drive the Unity Editor from an AI agent or the terminal. The Editor serves MCP itself, so there is no second process to run, and the isuzu-unity-cli command needs no Node or .NET runtime.",

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "4d9d178d462d72e6d7f285707d1020aa7a632b99816375834f2192a11e5bd39d",
-    "total":  508,
-    "passed":  507,
+    "sourceHash":  "d9e02d81bf67436fc8b4a2b32b305abb6f3578edadbb87cbbf19574c32234ecb",
+    "total":  525,
+    "passed":  524,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-08T01:54:39.5701124Z"
+    "ranAt":  "2026-09-08T16:00:03.7759041Z"
 }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.isuzu-shiranui/unity-mcp",
   "title": "Unity MCP",
   "description": "Drive a running Unity Editor from an AI agent. The Editor serves MCP itself over Streamable HTTP on the loopback interface, so there is no second server process; this package is the client that bridges stdio to it. Covers the console, compilation, the scene, assets, prefabs, materials, shaders, Animator Controllers, Timeline, the test runner, play mode, builds and screenshots.",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "repository": {
     "url": "https://github.com/isuzu-shiranui/UnityMCP",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "nuget",
       "identifier": "IsuzuUnityCli",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Browsing 523 objects cost 87,563 tokens. Most of it was carried without saying anything.

## What it costs now

Measured on one Editor holding all three packages, 523 objects deep 6, NativeAOT, 20 iterations.

| | bytes | tokens |
|---|---|---|
| before | 346,480 | 87,563 |
| the tree | 83,265 | 44,217 |
| the same read as a difference | 111 | 57 |

Process start 10.1 ms, tool list 13.0 ms, the whole hierarchy 41.4 ms, the difference 34.8 ms.

## Where the bytes went

The CLI indented every reply — 2.8x the bytes of a large one, and whatever reads it pays for the whitespace. Indentation now follows where the output goes: a terminal keeps it, a pipe or a redirect loses it, which is how an agent reads it. `--compact` forces the packed form anywhere.

A node carried `id` and `instanceId` from the same expression, equal on every object. Nothing in the repository read `id`.

A node carried four keys sitting at their default on every untouched object. They were 24 KB that said nothing.

## Reading it twice

Every reply names the state it describes with a `snapshotId`, and `since` takes one back to ask what changed. A snapshot is never consumed and never moves, so a second client reading the same scene cannot swallow the changes the first is waiting for, and a reply that never arrives leaves the last id usable.

Refused rather than answered wrongly: a diff with `limit` or `offset`, a snapshot compared against different filters, a snapshot the Editor no longer holds, and a `fields` allowlist that would drop `instanceId`. Each of those returned a confident wrong answer before.

`removed` names what left this result, not what was destroyed. A node in `changed` replaces rather than merges. Both are tests now, not sentences.

## Breaking

`id` is gone and default-valued keys are omitted, so a reply's shape changed. The CHANGELOG says what to read instead.

## Checks

EditMode 525, CLI 221, no failures. Attestation refreshed.