### PR TITLE
Publish under the domain rather than the GitHub account

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # Unity MCP Integration Framework
 
-<!-- mcp-name: io.github.isuzu-shiranui/unity-mcp -->
+<!-- mcp-name: dev.shiranui-isuzu/unity-mcp -->
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 ![Version](https://img.shields.io/badge/version-4.0.6-brightgreen)

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [4.1.1] - 2026-09-09
+
+### Changed
+- The registry entry moved from `io.github.isuzu-shiranui/unity-mcp` to
+  `dev.shiranui-isuzu/unity-mcp`, verified against the domain rather than the GitHub account.
+  The registry orders search results by name, and a search for "unity" is capped at 100: under
+  the old namespace this sat at 97 of them, behind every entry whose name merely contains
+  "comm**unity**". Under the new one it sits at 6. The name a package is published under is the
+  only lever on that, so it is worth the version this costs. The `mcp-name` marker the NuGet
+  README carries moves with it, which is what proves the two belong to the same owner.
+- The registry description names what the tools address — scenes, prefabs, assets, shaders,
+  Timeline, tests, builds — so a search for any of those reaches it. Capped at 100 characters.
+
 ## [4.1.0] - 2026-09-09
 
 ### Breaking

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.1.0";
+        private const string FallbackVersion = "4.1.1";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "Drive the Unity Editor from an AI agent or the terminal. The Editor serves MCP itself, so there is no second process to run, and the isuzu-unity-cli command needs no Node or .NET runtime.",

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "d9e02d81bf67436fc8b4a2b32b305abb6f3578edadbb87cbbf19574c32234ecb",
+    "sourceHash":  "6e917157f407cfbd09ad23c1f6d38c6ba224221f8e8da291b4a4535101a5f1f2",
     "total":  525,
     "passed":  524,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-08T16:00:03.7759041Z"
+    "ranAt":  "2026-09-08T16:33:48.7470231Z"
 }

--- a/server.json
+++ b/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.isuzu-shiranui/unity-mcp",
+  "name": "dev.shiranui-isuzu/unity-mcp",
   "title": "Unity MCP",
   "description": "Unity Editor automation for AI agents: scenes, prefabs, assets, shaders, Timeline, tests, builds.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "repository": {
     "url": "https://github.com/isuzu-shiranui/UnityMCP",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "nuget",
       "identifier": "IsuzuUnityCli",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The registry orders search results by name and caps a search at 100. Under `io.github.isuzu-shiranui` this entry sat at **97 of the 100** a search for `unity` returns — behind every entry whose name merely contains "comm**unity**", which is most of what fills those first ninety.

Under `dev.shiranui-isuzu` it sits at **6**.

| | position in a search for `unity` |
|---|---|
| `io.github.isuzu-shiranui/unity-mcp` | 97 / 100 |
| `dev.shiranui-isuzu/unity-mcp` | 6 / 100 |

The name is the only lever on that ordering — the description cannot move it — so it is worth the version this costs.

## How the namespace is held

From the domain, verified with an ed25519 key whose public half sits in a TXT record on `shiranui-isuzu.dev`. The `mcp-name` marker the NuGet README carries moves with it: that marker is what proves the package and the registry entry belong to the same owner, so the entry cannot move without a release that ships the new one. That is why this is a version rather than a registry-only edit.

## The description

It now names what the tools address rather than how they connect. A reader learns the mechanism from the README; a search only reaches what the description spells.

```
Unity Editor automation for AI agents: scenes, prefabs, assets, shaders, Timeline, tests, builds.
```

Capped at 100 characters by the registry — the first attempt at publishing was refused with a 422 for being 379.

## Checks

EditMode 525, CLI 221, no failures. Attestation refreshed.