### PR TITLE
fix: arguments the caller sets and the handler then ignores

### DIFF
--- a/docs/defined-tools.md
+++ b/docs/defined-tools.md
@@ -108,7 +108,7 @@ destructive なステップを 1 つでも含む `sequence` は、それ自体�
 | `destructive` | `false`（destructive なステップを含む `sequence` は `true`） | `true` なら `confirm` / `dry_run` が属性ツールと同じ形で注入される。destructive なステップを含む `sequence` に `false` を書くとロード時にエラー |
 | `undoGroup` | なし | `sequence` にだけ指定でき、`mainThread: true` が前提 |
 | `alwaysLoad` | `false` | ツール検索の裏に隠さず常にロード済みにする |
-| `maxResultSizeChars` | `0`（クライアントの既定のまま） | 結果テキストをファイルに書き出すしきい値を上げる |
+| `maxResultSizeChars` | `0`（クライアントの既定のまま） | クライアントに要求する上限（文字数）。ヒントとして `_meta` に載るだけで、パッケージ側は応答量を測りも切りもしません |
 | `inputs` | なし | 名前 → `{type, description, required?, default?, enum?}`。`type` は `string` / `integer` / `number` / `boolean` / `object` / `array` |
 | `examples` | なし | 引数オブジェクトの実例（JSON オブジェクトか JSON 文字列の配列） |
 

--- a/docs/en/defined-tools.md
+++ b/docs/en/defined-tools.md
@@ -108,7 +108,7 @@ The result is `{steps: [{id, tool, ok, result|error}, …]}`. This kind exists t
 | `destructive` | `false` (`true` for a `sequence` that contains a destructive step) | `true` injects `confirm`/`dry_run` the same way an attribute-based tool does. `false` on a `sequence` that contains a destructive step is a load error |
 | `undoGroup` | none | allowed only on `sequence`, and only with `mainThread: true` |
 | `alwaysLoad` | `false` | keeps the tool loaded rather than deferred behind tool search |
-| `maxResultSizeChars` | `0` (client default) | raises the size at which the result spills to a file |
+| `maxResultSizeChars` | `0` (client default) | the size this tool asks the client to allow, in characters. Published in `_meta` as a hint; nothing on this side measures or cuts a response |
 | `inputs` | none | name → `{type, description, required?, default?, enum?}`. `type` is `string`, `integer`, `number`, `boolean`, `object` or `array` |
 | `examples` | none | worked argument objects, as JSON objects or JSON strings |
 

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Cli/InlineImage.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Cli/InlineImage.cs
@@ -1,0 +1,73 @@
+using System.Text.Json.Nodes;
+
+namespace IsuzuUnityCli.Cli;
+
+/// <summary>
+/// Moves a base64 image out of a reply and onto disk before the reply is printed.
+/// </summary>
+/// <remarks>
+/// An MCP client turns that base64 into an image block, which a model is charged for by the
+/// picture's dimensions: a 825x845 screenshot costs about 940 tokens. Printed to stdout it is
+/// just a very long string, and whatever reads the terminal pays for it as text — 89,000 tokens
+/// for the same screenshot, ninety-five times the price for the same picture. The tool cannot
+/// tell which way its answer will travel, so the CLI decides here, on the way out.
+/// </remarks>
+public static class InlineImage
+{
+    /// <summary>Base64 of the eight-byte PNG signature. The ninth character varies with byte 9.</summary>
+    private const string PngPrefix = "iVBORw0KGg";
+
+    private const string Key = "image";
+
+    /// <summary>
+    /// Writes an inline PNG to <paramref name="directory"/> and replaces it with the path.
+    /// Returns the file written, or null when the reply carried no image.
+    /// </summary>
+    public static string? Externalise(JsonNode? result, string directory)
+    {
+        var carrier = Carrier(result);
+
+        if (carrier is null
+            || carrier[Key] is not JsonValue value
+            || !value.TryGetValue<string>(out var encoded)
+            || !encoded.StartsWith(PngPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(encoded);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, $"capture-{DateTime.Now:yyyyMMdd-HHmmss-fff}.png");
+        File.WriteAllBytes(path, bytes);
+
+        carrier.Remove(Key);
+        carrier["path"] = path;
+        carrier["note"] = "Written to disk rather than printed: inline the picture would be "
+                        + "tens of thousands of tokens of base64. Read this file to look at it.";
+
+        return path;
+    }
+
+    /// <summary>
+    /// The object holding the image. A job's detail nests the tool's answer under
+    /// <c>result</c>, so the image sits one level down there.
+    /// </summary>
+    private static JsonObject? Carrier(JsonNode? result)
+    {
+        if (result is not JsonObject body)
+        {
+            return null;
+        }
+
+        return body[Key] is null && body["result"] is JsonObject nested ? nested : body;
+    }
+}

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Cli/InlineImage.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Cli/InlineImage.cs
@@ -27,14 +27,12 @@ public static class InlineImage
     {
         var carrier = Carrier(result);
 
-        if (carrier is null
-            || carrier[Key] is not JsonValue value
-            || !value.TryGetValue<string>(out var encoded)
-            || !encoded.StartsWith(PngPrefix, StringComparison.Ordinal))
+        if (carrier is null)
         {
             return null;
         }
 
+        var encoded = carrier[Key]!.GetValue<string>();
         byte[] bytes;
         try
         {
@@ -57,17 +55,46 @@ public static class InlineImage
         return path;
     }
 
-    /// <summary>
-    /// The object holding the image. A job's detail nests the tool's answer under
-    /// <c>result</c>, so the image sits one level down there.
-    /// </summary>
-    private static JsonObject? Carrier(JsonNode? result)
+    /// <summary>The object holding an <c>image</c> that is base64 of a PNG, or null.</summary>
+    /// <remarks>
+    /// Searched for rather than looked up in a fixed place. A capture answered inline carries the
+    /// PNG at the top, a job's detail nests it under <c>result</c>, and input_replay puts it under
+    /// <c>capture</c>. Each position that was hardcoded here printed the next tool's base64.
+    /// </remarks>
+    private static JsonObject? Carrier(JsonNode? node)
     {
-        if (result is not JsonObject body)
+        if (node is JsonObject body)
         {
-            return null;
+            if (body[Key] is JsonValue value
+                && value.TryGetValue<string>(out var encoded)
+                && encoded.StartsWith(PngPrefix, StringComparison.Ordinal))
+            {
+                return body;
+            }
+
+            foreach (var property in body)
+            {
+                var found = Carrier(property.Value);
+
+                if (found is not null)
+                {
+                    return found;
+                }
+            }
+        }
+        else if (node is JsonArray array)
+        {
+            foreach (var item in array)
+            {
+                var found = Carrier(item);
+
+                if (found is not null)
+                {
+                    return found;
+                }
+            }
         }
 
-        return body[Key] is null && body["result"] is JsonObject nested ? nested : body;
+        return null;
     }
 }

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/CommandContext.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/CommandContext.cs
@@ -57,6 +57,9 @@ public sealed class CommandContext
     {
         if (raw)
         {
+            // The envelope carries the same picture the result does, so --raw needs the same
+            // treatment: printed, a screenshot costs about ninety times what it does as a file.
+            ReportWritten(InlineImage.Externalise(envelope.Raw, CaptureDirectory));
             JsonOutput.Print(Out, envelope.Raw, Indented);
             ReportRunning(envelope);
             return envelope.IsError ? 1 : 0;
@@ -70,14 +73,18 @@ public sealed class CommandContext
 
         var written = InlineImage.Externalise(envelope.Result, CaptureDirectory);
         JsonOutput.Print(Out, envelope.Result, Indented);
-
-        if (written is not null)
-        {
-            Err.WriteLine($"image written to {written}");
-        }
-
+        ReportWritten(written);
         ReportRunning(envelope);
         return 0;
+    }
+
+    /// <summary>Names the file a picture went to, on stderr so it stays out of the JSON.</summary>
+    private void ReportWritten(string? path)
+    {
+        if (path is not null)
+        {
+            Err.WriteLine($"image written to {path}");
+        }
     }
 
     /// <summary>The <c>message</c> of a running job or a 202 envelope, or null for anything else.</summary>

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/CommandContext.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/CommandContext.cs
@@ -35,6 +35,14 @@ public sealed class CommandContext
     /// </summary>
     public bool Indented { get; init; }
 
+    /// <summary>
+    /// Where an inline image is written instead of being printed. A screenshot costs about 940
+    /// tokens as a picture and 89,000 as base64 in a terminal, and only the caller knows which
+    /// way the answer is travelling.
+    /// </summary>
+    public string CaptureDirectory { get; init; } =
+        Path.Combine(Path.GetTempPath(), "isuzu-unity-cli");
+
     public InstanceDescriptor ResolveInstance(ParsedArgs parsed)
     {
         return InstanceResolver.Resolve(ReadDescriptors(), parsed.Option("project"), WorkingDirectory);
@@ -60,7 +68,14 @@ public sealed class CommandContext
             return 1;
         }
 
+        var written = InlineImage.Externalise(envelope.Result, CaptureDirectory);
         JsonOutput.Print(Out, envelope.Result, Indented);
+
+        if (written is not null)
+        {
+            Err.WriteLine($"image written to {written}");
+        }
+
         ReportRunning(envelope);
         return 0;
     }

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.1.2</Version>
+    <Version>4.2.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/CommandContextTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/CommandContextTests.cs
@@ -11,6 +11,12 @@ public sealed class CommandContextTests
          "message":"'execute_code' is still running on the Editor main thread. The Editor is showing a dialog \"MCP probe\" (Pick one) with buttons Yes / No."}}
         """;
 
+    // A one-pixel PNG, base64-encoded: the signature is what the check reads.
+    private const string Shot = """
+        {"status":"success","result":{"view":"game","width":2,
+         "image":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="}}
+        """;
+
     // Indentation is stated rather than inherited: its default reads Console.IsOutputRedirected,
     // which depends on how the test host was started.
     private static (CommandContext Context, StringWriter Out, StringWriter Err) Context(bool indented = true)
@@ -54,6 +60,39 @@ public sealed class CommandContextTests
 
         Assert.Contains("\"status\": \"success\"", output.ToString());
         Assert.Contains("showing a dialog", error.ToString());
+    }
+
+    [Fact]
+    public void RawOutputWritesAPictureToDiskRatherThanPrintingIt()
+    {
+        // --raw prints the envelope instead of the result, and used to return before the picture
+        // was moved, so the same screenshot cost ninety times as much through that one flag.
+        var directory = Path.Combine(Path.GetTempPath(), "raw-image-" + Guid.NewGuid().ToString("N"));
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var context = new CommandContext
+        {
+            Out = output,
+            Err = error,
+            Indented = false,
+            CaptureDirectory = directory,
+        };
+
+        try
+        {
+            context.Report(Envelope.Parse(200, Shot), raw: true);
+
+            Assert.DoesNotContain("iVBORw0KGg", output.ToString());
+            Assert.Contains("\"width\":2", output.ToString());
+            Assert.Contains("image written to", error.ToString());
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
     }
 
     [Fact]

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/InlineImageTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/InlineImageTests.cs
@@ -75,6 +75,35 @@ public sealed class InlineImageTests : IDisposable
     }
 
     [Fact]
+    public void ACaptureTakenAlongsideOtherWorkIsFoundToo()
+    {
+        // input_replay's then_capture puts the picture under `capture`, beside what the replay
+        // itself reports. Looking only at the top and at `result` printed the base64.
+        var reply = new JsonObject
+        {
+            ["sent"] = 2,
+            ["window"] = "Game",
+            ["capture"] = Reply(),
+        };
+
+        var path = InlineImage.Externalise(reply, directory);
+
+        Assert.NotNull(path);
+        Assert.Null(reply["capture"]!["image"]);
+        Assert.Equal(path, (string?)reply["capture"]!["path"]);
+        Assert.Equal(2, (int?)reply["sent"]);
+    }
+
+    [Fact]
+    public void APictureInsideAnArrayIsFound()
+    {
+        var reply = new JsonObject { ["captures"] = new JsonArray(Reply()) };
+
+        Assert.NotNull(InlineImage.Externalise(reply, directory));
+        Assert.Null(reply["captures"]![0]!["image"]);
+    }
+
+    [Fact]
     public void AReplyWithoutAPictureIsUntouched()
     {
         var reply = new JsonObject { ["isPlaying"] = false };

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/InlineImageTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/InlineImageTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json.Nodes;
+using IsuzuUnityCli.Cli;
+using Xunit;
+
+namespace IsuzuUnityCli.Tests;
+
+public sealed class InlineImageTests : IDisposable
+{
+    // A real PNG: the signature matters, because that is what the check reads.
+    private static readonly byte[] Png =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89,
+    ];
+
+    private readonly string directory =
+        Path.Combine(Path.GetTempPath(), "inline-image-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private JsonObject Reply() => new()
+    {
+        ["view"] = "game_view_window",
+        ["width"] = 825,
+        ["image"] = Convert.ToBase64String(Png),
+    };
+
+    [Fact]
+    public void APictureIsWrittenToDiskRatherThanPrinted()
+    {
+        // Printed, the base64 is read as text and costs about ninety times what the picture
+        // costs as an image.
+        var reply = Reply();
+
+        var path = InlineImage.Externalise(reply, directory);
+
+        Assert.NotNull(path);
+        Assert.Null(reply["image"]);
+        Assert.Equal(path, (string?)reply["path"]);
+        Assert.NotNull(reply["note"]);
+        Assert.Equal(Png, File.ReadAllBytes(path!));
+    }
+
+    [Fact]
+    public void TheRestOfTheReplyIsLeftAlone()
+    {
+        var reply = Reply();
+
+        InlineImage.Externalise(reply, directory);
+
+        Assert.Equal("game_view_window", (string?)reply["view"]);
+        Assert.Equal(825, (int?)reply["width"]);
+    }
+
+    [Fact]
+    public void AJobDetailCarriesItsPictureOneLevelDown()
+    {
+        // job_status nests the tool's answer under `result`, and the image sits inside that.
+        var reply = new JsonObject { ["state"] = "completed", ["result"] = Reply() };
+
+        var path = InlineImage.Externalise(reply, directory);
+
+        Assert.NotNull(path);
+        Assert.Null(reply["result"]!["image"]);
+        Assert.NotNull(reply["result"]!["path"]);
+    }
+
+    [Fact]
+    public void AReplyWithoutAPictureIsUntouched()
+    {
+        var reply = new JsonObject { ["isPlaying"] = false };
+
+        Assert.Null(InlineImage.Externalise(reply, directory));
+        Assert.False(Directory.Exists(directory));
+    }
+
+    [Fact]
+    public void AStringThatIsNotAPngIsLeftWhereItIs()
+    {
+        // Only a PNG signature moves. Any other string named `image` belongs to the tool.
+        var reply = new JsonObject { ["image"] = "not a picture" };
+
+        Assert.Null(InlineImage.Externalise(reply, directory));
+        Assert.Equal("not a picture", (string?)reply["image"]);
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,14 +1,84 @@
 # Changelog
 
-## [4.1.2] - 2026-09-09
+## [4.2.0] - 2026-09-09
+
+### Breaking
+- `project_assemblies` no longer returns `fullName`. It held the assembly name and version that
+  `name` and `version` already carry, followed by the same `Culture=neutral, PublicKeyToken=null`
+  on almost every row. Dropping it halves the reply: 24,350 tokens to 12,248 on a project with 249
+  loaded assemblies. Read `name` and `version`.
+- A `fields` list that matches nothing on the entries returned is refused with `invalid_params`
+  instead of answered with empty objects. Three tools took the same parameter and did three
+  different things with a name that matched nothing — empty objects, everything but the
+  identifier, or the filter ignored altogether — and none of them said anything was wrong. The
+  error names the fields the entries do carry. `console_read_logs` takes `t`, `m`, `f` and `l`,
+  which its description now says.
+- Thirty tools declare arguments their handlers already refused to work without: `asset_info`,
+  `asset_create_folder`, `asset_move`, `asset_delete`, `asset_reimport`, `reflect_read`,
+  `reflect_find_type`, `render_compare`, `build_player`, `scene_open`, `prefab_create`,
+  `prefab_instantiate`, `gameobject_add_component`, `gameobject_remove_component`,
+  `input_pointer`, nine `animator_*` tools and six `timeline_*` tools. A client that validates
+  arguments against the schema will now refuse these calls up front rather than sending them to
+  be rejected. Arguments wanted only in some situations — `input_pointer`'s `to`, `material_set`'s
+  `value`, the `timeline_*` clip selectors — stay optional.
 
 ### Fixed
-- A screenshot taken through the CLI is written to a file, and the reply carries the path.
-  It used to print the picture as base64. An MCP client turns that base64 into an image block,
-  which a model is charged for by the picture's dimensions — about 940 tokens for an 825x845
-  capture. Printed to a terminal the same bytes are read as text: 89,000 tokens, ninety-five
-  times the price for the same picture. The tool cannot tell which way its answer will travel,
-  so the CLI decides on the way out. The MCP path is unchanged and still carries the image.
+- A screenshot taken through the CLI is written to a file and the reply carries the path. Printed,
+  the base64 is read as text: about 89,000 tokens for an 825x845 capture against 940 as an image.
+  The picture is now found wherever the tool puts it — at the top of the reply, under `result`
+  when it arrives through `job_status`, or under `capture` when `input_replay` takes one — rather
+  than in two fixed places. `--raw` prints through the same path; it used to return before the
+  picture was moved.
+- `input_replay` with `then_capture` and no `capture_path` sent the PNG as base64 over MCP as well
+  as the CLI: 80,216 tokens as a text block against 785 as an image. It reached an MCP client as
+  `type: "text"` because the endpoint looked for the picture in two fixed places and the capture
+  sits under `capture`.
+- An MCP reply carried the base64 twice, once as an image block and once inside
+  `structuredContent`. A capture's reply is halved, from 169,806 characters to 85,021.
+- `project_packages` with `include_registry` returned the whole registry however small a `limit`
+  was asked for, because the registry half was built outside the paging. `limit: 2` returned 175
+  registry entries and 29,214 tokens; it now returns two, with `registryCount` naming the total.
+- `inspect_write` with no `component_type` listed the object's components and wrote nothing,
+  reporting a result rather than a failure. A read or a write with no component named now targets
+  the GameObject itself, which is what those tools describe. The components view answers a listing.
+- `inspect_list` ignored `offset` and `limit` when a `component_type` was named, returning every
+  property whatever was asked for.
+- `console_read_logs` compared an unknown `type` against each severity in turn and matched none,
+  so the filter narrowed nothing and every entry came back. `type: "ERROR"` is now refused.
+- `capture_screenshot` scaled an explicit `width` or `height` down to `max_size`, which their
+  descriptions say they override: 2048 came back as 1024 with nothing said. They are now honoured,
+  and an edge past 4096 is refused rather than quietly shrunk.
+- `timeline_inspect` discarded `include_clips` when it followed a Control track into a child
+  timeline, so a caller asking for no clips got them anyway from the nested one.
+- A refusal raised inside `console_read_logs`, `scene_browse_hierarchy` or `inspect_*` was folded
+  into that tool's generic failure message, so a wrong argument read as the Editor being
+  unreadable and a caller retried instead of correcting what it sent.
+
+### Changed
+- `console_read_logs` keeps the stack frames that name a file and a line, and replaces the rest
+  with a count and the assemblies they came from. Cutting each message at 500 characters spent the
+  budget on the test runner rather than the test: on a fifty-entry read, none of the fifty kept a
+  frame that could be opened, several severed mid-path. Paths are cut to their last three
+  segments. `test_results` reports a failure's trace the same way.
+- `editor_log_tail` folds lines whose shape repeats, keeping the first whole and counting the
+  rest, and applies the same stack trimming. A line reporting a problem is never folded. The
+  default read drops from 14,341 tokens to 3,335, and the 2,000-line cap from 110,059 to 54,822.
+- `editor_log_tail` gained `since`, which takes the `position` a previous reply returned and
+  answers with what the log has gained since. Checking the log after an action costs 105 tokens
+  rather than reading the tail again.
+- Ceilings where a reply's size followed the project rather than the request: `reflect_read` walks
+  at most 2,000 nodes, four levels deep, 200 items per collection, and cuts a string at 4,000
+  characters — depth and item count multiply, so neither bounds a reply on its own.
+  `gpu_readback` caps `samples` and `histogram` at 256; `animator_inspect` reports 120 states and
+  24 transitions each; `asset_info` lists 200 dependencies; `render_camera_info` reports 50
+  cameras. Each says what it left out and how many there were.
+- `render_camera_info` matches `name` as a case-insensitive substring. Exact matching selected one
+  camera or none, so a caller looking at a group had no way to ask for less than all of them.
+- `project_packages` leaves out `author` when nobody filled it in, rather than three empty strings
+  on every row.
+- `maxResultSizeChars` is documented as what it is: a hint published in `_meta` for the client to
+  act on. Nothing in the package measures a response or cuts one, so a tool can and does answer
+  above its own stated number.
 
 ## [4.1.1] - 2026-09-09
 

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [4.1.2] - 2026-09-09
+
+### Fixed
+- A screenshot taken through the CLI is written to a file, and the reply carries the path.
+  It used to print the picture as base64. An MCP client turns that base64 into an image block,
+  which a model is charged for by the picture's dimensions — about 940 tokens for an 825x845
+  capture. Printed to a terminal the same bytes are read as text: 89,000 tokens, ninety-five
+  times the price for the same picture. The tool cannot tell which way its answer will travel,
+  so the CLI decides on the way out. The MCP path is unchanged and still carries the image.
+
 ## [4.1.1] - 2026-09-09
 
 ### Changed

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/Attributes/McpToolAttribute.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/Attributes/McpToolAttribute.cs
@@ -94,14 +94,14 @@ namespace UnityMCP.Editor.Core.Attributes
         public bool AlwaysLoad { get; set; }
 
         /// <summary>
-        /// Raises the size at which this tool's text result is spilled to a file instead of
-        /// being returned inline, in characters. Zero leaves the client's default in place.
+        /// What this tool asks the client to allow before it writes the result to a file rather
+        /// than passing it inline, in characters. Zero leaves the client's default in place.
         /// </summary>
         /// <remarks>
-        /// For tools whose useful answer is genuinely large — a deep hierarchy, a long log tail —
-        /// the default truncation loses the part the caller asked for. This does nothing for image
-        /// results, so it will not help a screenshot. Surfaced as
-        /// <c>anthropic/maxResultSizeChars</c> in the tool's <c>_meta</c>.
+        /// A hint, and nothing more: it is published as <c>anthropic/maxResultSizeChars</c> in the
+        /// tool's <c>_meta</c> and read by the client. Nothing on this side measures a response or
+        /// cuts one, so a tool can and does answer above its own stated number — what bounds a
+        /// reply is the tool's own paging and ceilings. It says nothing about an image result.
         /// </remarks>
         public int MaxResultSizeChars { get; set; }
 

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/ListResponseBuilder.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/ListResponseBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Newtonsoft.Json.Linq;
 
@@ -26,12 +27,17 @@ namespace UnityMCP.Editor.Core
         /// A JObject with keys <c>items</c> (JArray), <c>truncated</c> (bool), and
         /// <c>next</c> ({offset, limit} or null).
         /// </returns>
+        /// <param name="alwaysKeep">
+        /// Fields the tool keeps whatever the caller asked for. They are not the caller's names,
+        /// so they do not count as a match when deciding whether the request named anything real.
+        /// </param>
         public static JObject Build<T>(
             IReadOnlyList<T> items,
             int offset,
             int limit,
             Func<T, JObject> projector,
-            string[] fieldsFilter = null)
+            string[] fieldsFilter = null,
+            string[] alwaysKeep = null)
         {
             if (items == null) throw new ArgumentNullException(nameof(items));
             if (projector == null) throw new ArgumentNullException(nameof(projector));
@@ -46,15 +52,43 @@ namespace UnityMCP.Editor.Core
             var truncated = actualEnd < total;
 
             var resultArray = new JArray();
+            var filtering = fieldsFilter != null && fieldsFilter.Length > 0;
+            var matchedSomething = false;
+            var available = new SortedSet<string>(StringComparer.Ordinal);
+            var asked = filtering ? new HashSet<string>(fieldsFilter, StringComparer.Ordinal) : null;
+            var kept = filtering ? Union(fieldsFilter, alwaysKeep) : null;
 
             for (var i = offset; i < actualEnd; i++)
             {
                 var projected = projector(items[i]);
-                if (fieldsFilter != null && fieldsFilter.Length > 0)
+
+                if (filtering)
                 {
-                    projected = ApplyFieldsFilter(projected, fieldsFilter);
+                    foreach (var property in projected.Properties())
+                    {
+                        available.Add(property.Name);
+
+                        if (asked.Contains(property.Name))
+                        {
+                            matchedSomething = true;
+                        }
+                    }
+
+                    projected = ApplyFieldsFilter(projected, kept);
                 }
+
                 resultArray.Add(projected);
+            }
+
+            // Judged over the page rather than per row: a row omitting an optional field says
+            // nothing about whether the tool has it.
+            if (filtering && !matchedSomething && available.Count > 0)
+            {
+                throw new McpToolException(
+                    "invalid_params",
+                    $"'fields' matched nothing on the {resultArray.Count} entries returned, which "
+                    + $"carry: {string.Join(", ", available)}. A field that is left out when it "
+                    + "holds its default value will not appear among them.");
             }
 
             JObject next = null;
@@ -89,6 +123,26 @@ namespace UnityMCP.Editor.Core
                 result[i] = result[i].Trim();
 
             return result.Length == 0 ? null : result;
+        }
+
+        private static string[] Union(string[] first, string[] second)
+        {
+            if (second == null || second.Length == 0)
+            {
+                return first;
+            }
+
+            var all = new List<string>(first);
+
+            foreach (var name in second)
+            {
+                if (!all.Contains(name))
+                {
+                    all.Add(name);
+                }
+            }
+
+            return all.ToArray();
         }
 
         private static JObject ApplyFieldsFilter(JObject source, string[] allowedKeys)

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/LogNoise.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/LogNoise.cs
@@ -1,0 +1,291 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace UnityMCP.Editor.Core
+{
+    /// <summary>
+    /// Cuts a log down to what a reader can act on: the message, and the frames naming a file and
+    /// a line.
+    /// </summary>
+    /// <remarks>
+    /// Cutting by character count spends the budget on whatever came first, which under a test
+    /// runner is the machinery that called the test rather than the test. A 500-character cut
+    /// drops the located frame from a typical NUnit trace, severing it mid-path so neither file
+    /// nor line survives.
+    /// </remarks>
+    internal static class LogNoise
+    {
+        /// <summary>
+        /// A frame Unity printed: <c>Namespace.Type:Method (</c>, nested types included, or one of
+        /// Mono's generated thunks. The thunks matter because a line the run does not recognise
+        /// splits the trace in two, and each half then keeps its own quota of frames.
+        /// </summary>
+        private static readonly Regex Frame =
+            new Regex(@"^(\(wrapper [\w -]+\)\s*)?[\w.<>+`|/]+:[\w<>$|.`]+\s*\(", RegexOptions.Compiled);
+
+        /// <summary>
+        /// A frame that names where it ran. Matched from the end because a Windows path carries a
+        /// drive letter, so the colon before the line number is not the only one on the line.
+        /// </summary>
+        private static readonly Regex Located =
+            new Regex(@"\(at .+:\d+\)\s*$", RegexOptions.Compiled);
+
+        /// <summary>The Debug.Log call itself, which is on every trace and names nothing.</summary>
+        private static readonly Regex LoggingCall =
+            new Regex(@"^UnityEngine\.(Debug|Logger):Log", RegexOptions.Compiled);
+
+        /// <summary>What makes two otherwise identical lines differ: ids, times, counts.</summary>
+        private static readonly Regex Varying =
+            new Regex(@"[0-9a-f]{8,}|\d+\.\d+|\d+", RegexOptions.Compiled);
+
+        /// <summary>
+        /// A line reporting a problem is never folded away: two failures differing only by a
+        /// number are two failures.
+        /// </summary>
+        private static readonly Regex Trouble =
+            new Regex(@"error|exception|warning|fail|assert", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>Frames kept when the trace names no source at all, as engine crashes do.</summary>
+        private const int KeepWhenNoneLocated = 3;
+
+        /// <summary>
+        /// Located frames kept, nearest the failure first. In first-party code every frame names
+        /// source, so keeping all of them costs more than the untrimmed trace did.
+        /// </summary>
+        private const int MaxLocated = 4;
+
+        /// <summary>How many alike lines it takes before folding them is worth the note.</summary>
+        private const int FoldFrom = 3;
+
+        /// <summary>
+        /// Path segments kept in a frame's location. An absolute path repeats the machine and the
+        /// package root on every frame of every entry; three segments still name the file well
+        /// enough to open it.
+        /// </summary>
+        private const int PathSegments = 3;
+
+        /// <summary>The location at the end of a frame, so the path inside it can be shortened.</summary>
+        private static readonly Regex Location =
+            new Regex(@"\(at (?<path>.+):(?<line>\d+)\)\s*$", RegexOptions.Compiled);
+
+        /// <summary>One message with its stack reduced to the frames that name source.</summary>
+        public static string TrimStack(string message)
+        {
+            if (string.IsNullOrEmpty(message) || message.IndexOf('\n') < 0)
+            {
+                return message;
+            }
+
+            var lines = message.Replace("\r\n", "\n").Split('\n');
+            var kept = TrimStacks(lines);
+            var text = new StringBuilder();
+
+            for (var i = 0; i < kept.Count; i++)
+            {
+                if (i > 0)
+                {
+                    text.Append('\n');
+                }
+
+                text.Append(kept[i]);
+            }
+
+            return text.ToString();
+        }
+
+        /// <summary>
+        /// The same reduction over a list of lines, which is how the Editor log arrives: runs of
+        /// frames are replaced by the ones naming source, plus a note counting the rest.
+        /// </summary>
+        public static List<string> TrimStacks(IReadOnlyList<string> lines)
+        {
+            var output = new List<string>(lines.Count);
+            var run = new List<string>();
+
+            void Flush()
+            {
+                if (run.Count == 0)
+                {
+                    return;
+                }
+
+                var kept = new List<string>();
+                foreach (var frame in run)
+                {
+                    if (kept.Count == MaxLocated)
+                    {
+                        break;
+                    }
+
+                    if (Located.IsMatch(frame) && !LoggingCall.IsMatch(frame))
+                    {
+                        kept.Add(frame);
+                    }
+                }
+
+                // Nothing named source, so there is no better frame to choose than the first few.
+                if (kept.Count == 0)
+                {
+                    for (var i = 0; i < run.Count && i < KeepWhenNoneLocated; i++)
+                    {
+                        kept.Add(run[i]);
+                    }
+                }
+
+                foreach (var frame in kept)
+                {
+                    output.Add(Shorten(frame));
+                }
+
+                var hidden = run.Count - kept.Count;
+                if (hidden > 0)
+                {
+                    output.Add("    (+" + hidden + " frames via " + Origins(run, kept) + ")");
+                }
+
+                run.Clear();
+            }
+
+            foreach (var line in lines)
+            {
+                if (Frame.IsMatch(line))
+                {
+                    run.Add(line);
+                }
+                else
+                {
+                    Flush();
+                    output.Add(line);
+                }
+            }
+
+            Flush();
+            return output;
+        }
+
+        /// <summary>
+        /// Lines whose shape repeats folded to their first occurrence, which is kept verbatim so
+        /// the reader sees a real one rather than a pattern.
+        /// </summary>
+        /// <remarks>
+        /// Each shape is built once and carried to the second pass. Rebuilding it there costs
+        /// nearly half the work of the whole reduction: on the Editor's own Mono, 2000 lines took
+        /// 27.3 ms rebuilding against 15.8 ms carrying, for 1.08 MB against 561 KB.
+        /// </remarks>
+        public static List<string> FoldRepeats(IReadOnlyList<string> lines, out int folded)
+        {
+            var shapes = new string[lines.Count];
+            var counts = new Dictionary<string, int>();
+
+            for (var i = 0; i < lines.Count; i++)
+            {
+                if (!Foldable(lines[i]))
+                {
+                    continue;
+                }
+
+                var shape = Varying.Replace(lines[i], "#");
+                shapes[i] = shape;
+                counts.TryGetValue(shape, out var seenSoFar);
+                counts[shape] = seenSoFar + 1;
+            }
+
+            var output = new List<string>(lines.Count);
+            var written = new HashSet<string>();
+            folded = 0;
+
+            for (var i = 0; i < lines.Count; i++)
+            {
+                var shape = shapes[i];
+
+                // Null where the line was never foldable: a frame, or a line reporting a problem.
+                if (shape == null || counts[shape] < FoldFrom)
+                {
+                    output.Add(lines[i]);
+                    continue;
+                }
+
+                if (written.Add(shape))
+                {
+                    output.Add(lines[i] + "  [and " + (counts[shape] - 1) + " more like it]");
+                }
+                else
+                {
+                    folded++;
+                }
+            }
+
+            return output;
+        }
+
+        /// <summary>A frame with its location cut back to the last few path segments.</summary>
+        private static string Shorten(string frame)
+        {
+            var match = Location.Match(frame);
+
+            if (!match.Success)
+            {
+                return frame;
+            }
+
+            var path = match.Groups["path"].Value.Replace('\\', '/');
+            var segments = path.Split('/');
+
+            if (segments.Length <= PathSegments)
+            {
+                return frame;
+            }
+
+            var tail = string.Join("/", segments, segments.Length - PathSegments, PathSegments);
+
+            return frame.Substring(0, match.Index)
+                   + "(at " + tail + ":" + match.Groups["line"].Value + ")";
+        }
+
+        private static bool Foldable(string line)
+        {
+            return !Frame.IsMatch(line) && !Trouble.IsMatch(line);
+        }
+
+        /// <summary>The assemblies a hidden run passed through, for the note that replaces it.</summary>
+        private static string Origins(List<string> run, List<string> kept)
+        {
+            var names = new SortedSet<string>();
+
+            foreach (var frame in run)
+            {
+                if (kept.Contains(frame))
+                {
+                    continue;
+                }
+
+                var name = frame.StartsWith("(wrapper ") ? "generated thunks" : frame;
+                var end = name.IndexOfAny(new[] { '.', ':' });
+                names.Add(end > 0 ? name.Substring(0, end) : name);
+            }
+
+            var text = new StringBuilder();
+            var written = 0;
+
+            foreach (var name in names)
+            {
+                if (written == 4)
+                {
+                    text.Append(", …");
+                    break;
+                }
+
+                if (written > 0)
+                {
+                    text.Append(", ");
+                }
+
+                text.Append(name);
+                written++;
+            }
+
+            return text.ToString();
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/LogNoise.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/LogNoise.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2dd5763ed0e1e8b428a6145d42c7b303

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.1.2";
+        private const string FallbackVersion = "4.2.0";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.1.1";
+        private const string FallbackVersion = "4.1.2";
 
         private static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpStreamableHttpEndpoint.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpStreamableHttpEndpoint.cs
@@ -246,10 +246,12 @@ namespace UnityMCP.Editor.Core
                         return EndpointResponse.Json(200, RpcResult(id, ToolError($"Error [invalid_params]: {reported}")));
                     }
 
+                    var answered = WithoutInlineImage(outcome.Result, out var picture);
+
                     return EndpointResponse.Json(200, RpcResult(id, new JObject
                     {
-                        ["content"] = ResultContent(outcome.Result),
-                        ["structuredContent"] = outcome.Result,
+                        ["content"] = ResultContent(answered, picture),
+                        ["structuredContent"] = answered,
                     }));
 
                 case ToolCallOutcome.Kind.Failed:
@@ -297,38 +299,83 @@ namespace UnityMCP.Editor.Core
         }
 
         /// <summary>
-        /// The MCP content for a result, with an image carried as an image rather than as text.
+        /// The result with its inline PNG taken out, and that PNG, so the picture can travel as
+        /// image content instead of as text.
         /// </summary>
         /// <remarks>
         /// A capture returns its PNG base64-encoded. Left inside the JSON it is a wall of text a
         /// model cannot look at, and a small screenshot is large enough to crowd out everything
-        /// else in the reply. As image content the client renders it and the model sees the
-        /// picture, which is the whole point of asking for one. The base64 is taken out of the
-        /// structured copy for the same reason.
+        /// else in the reply. The structured copy is stripped too: keeping it there shipped the
+        /// same picture twice, once priced by its size and once by its dimensions.
         /// </remarks>
-        private static JArray ResultContent(JObject result)
+        private static JObject WithoutInlineImage(JObject result, out string image)
         {
-            // A capture answered inline carries the PNG at the top; fetched through job_status it
-            // sits under "result", because that reply is the job's detail rather than the tool's
-            // own. Looking only at the top meant the same screenshot came back as an image when
-            // the Editor was idle and as a wall of base64 when it was busy.
-            var carrier = result?["result"] as JObject ?? result;
-            var image = carrier?["image"];
+            image = null;
 
-            if (image == null || image.Type != JTokenType.String || !IsEncodedPng(image.ToString()))
+            if (ImageCarrier(result) == null)
             {
-                return TextContent(result.ToString(Formatting.None));
+                return result;
             }
 
             var describing = (JObject)result.DeepClone();
+            var carrier = ImageCarrier(describing);
 
-            if (describing["result"] is JObject nested)
+            image = carrier["image"].ToString();
+            carrier.Remove("image");
+
+            return describing;
+        }
+
+        /// <summary>The object holding an <c>image</c> that is base64 of a PNG, or null.</summary>
+        /// <remarks>
+        /// Searched for rather than looked up in a fixed place. A capture answered inline carries
+        /// the PNG at the top, job_status nests it under <c>result</c> because that reply is the
+        /// job's detail rather than the tool's own, and input_replay puts it under <c>capture</c>.
+        /// Each position that was hardcoded here shipped the next tool's base64 as text.
+        /// </remarks>
+        private static JObject ImageCarrier(JToken node)
+        {
+            if (node is JObject body)
             {
-                nested.Remove("image");
+                if (body["image"] is JValue value
+                    && value.Type == JTokenType.String
+                    && IsEncodedPng(value.ToString()))
+                {
+                    return body;
+                }
+
+                foreach (var property in body.Properties())
+                {
+                    var found = ImageCarrier(property.Value);
+
+                    if (found != null)
+                    {
+                        return found;
+                    }
+                }
             }
-            else
+            else if (node is JArray array)
             {
-                describing.Remove("image");
+                foreach (var item in array)
+                {
+                    var found = ImageCarrier(item);
+
+                    if (found != null)
+                    {
+                        return found;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>The MCP content for a result whose picture has already been taken out.</summary>
+        private static JArray ResultContent(JObject describing, string image)
+        {
+            if (image == null)
+            {
+                return TextContent(describing.ToString(Formatting.None));
             }
 
             return new JArray
@@ -337,7 +384,7 @@ namespace UnityMCP.Editor.Core
                 new JObject
                 {
                     ["type"] = "image",
-                    ["data"] = image.ToString(),
+                    ["data"] = image,
                     ["mimeType"] = "image/png",
                 },
             };

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/AssembliesResourceHandler.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/AssembliesResourceHandler.cs
@@ -69,10 +69,12 @@ namespace UnityMCP.Editor.Resources
         private JObject CreateAssemblyObject(Assembly assembly)
         {
             var assemblyName = assembly.GetName();
+
+            // No fullName: it is name, version, and the same culture and token boilerplate on
+            // every row, so it repeated what the other two fields already say.
             return new JObject
             {
                 ["name"] = assemblyName.Name,
-                ["fullName"] = assembly.FullName,
                 ["version"] = assemblyName.Version?.ToString(),
                 ["assemblyType"] = this.GetAssemblyType(assembly)
             };

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/InspectorAccess.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/InspectorAccess.cs
@@ -46,40 +46,62 @@ namespace UnityMCP.Editor.Handlers
                     return new JObject { ["error"] = "GameObject not found" };
                 }
 
-                // No componentType: list all components (context-economy aware).
+                var offset = parameters["offset"]?.Value<int>() ?? 0;
+                var limit = parameters["limit"]?.Value<int>() ?? 0;
+                var fields = ListResponseBuilder.ParseFieldsParam(parameters["fields"]?.ToString());
+
+                // The components view answers a listing only. A read or a write with no component
+                // named targets the GameObject itself, which is what those tools promise; sending
+                // them here answered a write with a component list and wrote nothing.
+                if (mode == "list" && string.IsNullOrEmpty(componentType))
+                {
+                    var detail = parameters["detail"]?.ToString() ?? "standard";
+                    return ListComponents(
+                        go, offset, limit <= 0 ? int.MaxValue : limit, fields, detail);
+                }
+
+                SerializedObject serializedObject;
+                string target;
+
                 if (string.IsNullOrEmpty(componentType))
                 {
-                    var listOffset = parameters["offset"]?.Value<int>() ?? 0;
-                    var listLimit = parameters["limit"]?.Value<int>() ?? int.MaxValue;
-                    var listFields = ListResponseBuilder.ParseFieldsParam(parameters["fields"]?.ToString());
-                    var detail = parameters["detail"]?.ToString() ?? "standard";
-                    return ListComponents(go, listOffset, listLimit, listFields, detail);
+                    serializedObject = new SerializedObject(go);
+                    target = "GameObject";
                 }
-
-                // Find the target component
-                var component = FindComponent(go, componentType, componentIndex);
-                if (component == null)
+                else
                 {
-                    return new JObject
+                    var component = FindComponent(go, componentType, componentIndex);
+                    if (component == null)
                     {
-                        ["error"] = $"Component '{componentType}' (index {componentIndex}) not found on '{go.name}'"
-                    };
-                }
+                        return new JObject
+                        {
+                            ["error"] = $"Component '{componentType}' (index {componentIndex}) not found on '{go.name}'"
+                        };
+                    }
 
-                var serializedObject = new SerializedObject(component);
+                    serializedObject = new SerializedObject(component);
+                    target = componentType;
+                }
 
                 if (mode == "write")
                 {
-                    return WriteProperty(serializedObject, propertyPath, value, componentType);
+                    return WriteProperty(serializedObject, propertyPath, value, target);
                 }
 
                 // Read mode
                 if (string.IsNullOrEmpty(propertyPath))
                 {
-                    return ListProperties(serializedObject, componentType);
+                    return ListProperties(serializedObject, target, offset, limit, fields);
                 }
 
-                return ReadProperty(serializedObject, propertyPath, componentType);
+                return ReadProperty(serializedObject, propertyPath, target);
+            }
+            catch (McpToolException)
+            {
+                // A refusal answers the request. Folded into the failure below it reads as the
+                // Editor being unreadable, and a caller retries rather than correcting what it
+                // sent.
+                throw;
             }
             catch (Exception e)
             {
@@ -234,24 +256,28 @@ namespace UnityMCP.Editor.Handlers
             return null;
         }
 
-        private static JObject ListProperties(SerializedObject serializedObject, string componentType)
+        private static JObject ListProperties(
+            SerializedObject serializedObject, string componentType, int offset, int limit, string[] fields)
         {
-            var properties = new JArray();
+            var all = new List<JObject>();
             var iterator = serializedObject.GetIterator();
             var enterChildren = true;
-            var count = 0;
 
-            while (iterator.NextVisible(enterChildren) && count < MaxProperties)
+            while (iterator.NextVisible(enterChildren) && all.Count < MaxProperties)
             {
                 enterChildren = false;
-                properties.Add(BuildPropertyInfo(iterator));
-                count++;
+                all.Add(BuildPropertyInfo(iterator));
             }
+
+            var page = ListResponseBuilder.Build(all, offset, limit, item => item, fields);
 
             return new JObject
             {
                 ["component"] = componentType,
-                ["properties"] = properties
+                ["properties"] = page["items"],
+                ["count"] = all.Count,
+                ["truncated"] = page["truncated"],
+                ["next"] = page["next"],
             };
         }
 

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/LogReader.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/LogReader.cs
@@ -70,6 +70,17 @@ namespace UnityMCP.Editor.Handlers
                     ?? 50;
                 var offset = parameters["offset"]?.Value<int>() ?? 0;
                 var typeFilter = parameters["type"]?.ToString() ?? "all";
+
+                // Checked here rather than in the loop: the loop compares against each name in
+                // turn, so one it does not know narrows nothing and every severity comes back.
+                if (typeFilter != "all" && typeFilter != "error"
+                    && typeFilter != "warning" && typeFilter != "log")
+                {
+                    throw new McpToolException(
+                        "invalid_params",
+                        $"'{typeFilter}' is not a severity. Use all, error, warning or log.");
+                }
+
                 var fieldsParam = parameters["fields"]?.ToString();
                 var fieldsFilter = ListResponseBuilder.ParseFieldsParam(fieldsParam);
 
@@ -108,8 +119,7 @@ namespace UnityMCP.Editor.Handlers
                         var file = (string)FileField.GetValue(entry) ?? "";
                         var line = (int)LineField.GetValue(entry);
 
-                        if (message.Length > 500)
-                            message = message.Substring(0, 500) + "...";
+                        message = LogNoise.TrimStack(message);
 
                         allEntries.Add(new JObject
                         {
@@ -152,6 +162,13 @@ namespace UnityMCP.Editor.Handlers
                 {
                     EndGettingEntriesMethod.Invoke(null, null);
                 }
+            }
+            catch (McpToolException)
+            {
+                // A refusal is an answer about the request. Folded into the generic failure below
+                // it reads as the console being unreadable, and a caller retries instead of
+                // correcting what it sent.
+                throw;
             }
             catch (Exception e)
             {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/PackagesResourceHandler.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/PackagesResourceHandler.cs
@@ -45,8 +45,19 @@ namespace UnityMCP.Editor.Resources
 
             if (includeRegistry)
             {
-                var registryPackages = this.GetRegistryPackages();
-                result["registryPackages"] = registryPackages;
+                // Paged like the project list. Built outside the builder, the whole registry came
+                // back however small a limit the caller asked for.
+                var registry = this.GetRegistryPackages();
+                var registryPage = ListResponseBuilder.Build(
+                    registry,
+                    offset,
+                    limit,
+                    p => this.PackageToJObject(p, "available"),
+                    fieldsFilter);
+
+                result["registryPackages"] = registryPage["items"];
+                result["registryCount"] = registry.Count;
+                result["registryTruncated"] = registryPage["truncated"];
             }
 
             return result;
@@ -75,9 +86,9 @@ namespace UnityMCP.Editor.Resources
             return result;
         }
 
-        private JArray GetRegistryPackages()
+        private List<PackageInfo> GetRegistryPackages()
         {
-            var result = new JArray();
+            var result = new List<PackageInfo>();
             var searchRequest = Client.SearchAll();
 
             while (!searchRequest.IsCompleted)
@@ -88,7 +99,7 @@ namespace UnityMCP.Editor.Resources
             if (searchRequest.Status == StatusCode.Success)
             {
                 foreach (var package in searchRequest.Result)
-                    result.Add(this.PackageToJObject(package, "available"));
+                    result.Add(package);
             }
             else if (searchRequest.Status == StatusCode.Failure)
             {
@@ -100,7 +111,7 @@ namespace UnityMCP.Editor.Resources
 
         private JObject PackageToJObject(PackageInfo package, string state)
         {
-            return new JObject
+            var json = new JObject
             {
                 ["name"] = package.name,
                 ["displayName"] = package.displayName,
@@ -109,13 +120,23 @@ namespace UnityMCP.Editor.Resources
                 ["category"] = package.category,
                 ["source"] = package.source.ToString(),
                 ["state"] = state,
-                ["author"] = new JObject
+            };
+
+            // Registry packages mostly leave the author blank, and three empty strings on every
+            // row cost more than the field is worth.
+            if (!string.IsNullOrEmpty(package.author?.name)
+                || !string.IsNullOrEmpty(package.author?.email)
+                || !string.IsNullOrEmpty(package.author?.url))
+            {
+                json["author"] = new JObject
                 {
                     ["name"] = package.author?.name,
                     ["email"] = package.author?.email,
                     ["url"] = package.author?.url
-                }
-            };
+                };
+            }
+
+            return json;
         }
     }
 }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/SceneHierarchy.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/SceneHierarchy.cs
@@ -36,15 +36,8 @@ namespace UnityMCP.Editor.Handlers
                 // Identity is what a diff is built on, and every reply is one a later call can
                 // diff against, so the allowlist never drops it. Left out, each node would fail
                 // to match itself and the comparison would report a still scene however much
-                // had moved.
-                if (fieldsFilter != null && fieldsFilter.Length > 0
-                    && Array.IndexOf(fieldsFilter, "instanceId") < 0)
-                {
-                    var widened = new string[fieldsFilter.Length + 1];
-                    Array.Copy(fieldsFilter, widened, fieldsFilter.Length);
-                    widened[fieldsFilter.Length] = "instanceId";
-                    fieldsFilter = widened;
-                }
+                // had moved. It goes to the builder as alwaysKeep rather than into the filter,
+                // so it cannot stand in for a field name the caller got wrong.
 
                 // Two different walks describe two different sets of objects. Comparing across
                 // them reports everything the narrower one leaves out as removed, which is a
@@ -134,7 +127,8 @@ namespace UnityMCP.Editor.Handlers
                         offset,
                         effectiveLimit,
                         ProjectFlatNode,
-                        fieldsFilter
+                        fieldsFilter,
+                        IdentityField
                     );
                 }
                 finally
@@ -174,6 +168,13 @@ namespace UnityMCP.Editor.Handlers
                 };
 
                 return result;
+            }
+            catch (McpToolException)
+            {
+                // A refusal answers the request. Folded into the failure below it reads as the
+                // Editor being unreadable, and a caller retries rather than correcting what it
+                // sent.
+                throw;
             }
             catch (Exception e)
             {
@@ -343,6 +344,14 @@ namespace UnityMCP.Editor.Handlers
                 CollectFilteredFlat(child, sceneIndex, myIndex, flat);
             }
         }
+
+        /// <summary>Kept on every node however the caller narrows the reply.</summary>
+        /// <remarks>
+        /// Not <c>[ThreadStatic]</c>: an initialiser on such a field runs only on the thread that
+        /// first touched the class, and this is read from the Editor's main thread, where it would
+        /// be null.
+        /// </remarks>
+        private static readonly string[] IdentityField = { "instanceId" };
 
         /// <summary>
         /// The flat list the current page is being projected from. <see cref="ProjectFlatNode"/>

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/ScreenshotCapture.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Handlers/ScreenshotCapture.cs
@@ -21,6 +21,13 @@ namespace UnityMCP.Editor.Handlers
     internal static class ScreenshotCapture
     {
         /// <summary>
+        /// Largest edge an explicit width or height may ask for. A picture is priced by its area,
+        /// so a 4096-square capture already costs a model about twenty thousand tokens; past this
+        /// the call is refused rather than quietly shrunk.
+        /// </summary>
+        private const int MaxRequestedEdge = 4096;
+
+        /// <summary>
         /// Editor panel view to window type name. Owned by <see cref="EditorWindowLocator"/> so
         /// capture and input replay cannot disagree about what a view name refers to.
         /// </summary>
@@ -185,7 +192,20 @@ namespace UnityMCP.Editor.Handlers
                     return new JObject { ["error"] = "Invalid capture dimensions" };
                 }
 
-                if (captureWidth > maxSize || captureHeight > maxSize)
+                if (requestedWidth > MaxRequestedEdge || requestedHeight > MaxRequestedEdge)
+                {
+                    throw new McpScreenshotException(
+                        "invalid_params",
+                        $"width and height are capped at {MaxRequestedEdge}. A picture costs a "
+                        + "model by its area, and this one would be larger than any view of it needs.",
+                        400);
+                }
+
+                // max_size shapes what the caller did not ask for. Applying it to an explicit
+                // width or height contradicted their documented meaning and said nothing about it.
+                var sized = requestedWidth.HasValue || requestedHeight.HasValue;
+
+                if (!sized && (captureWidth > maxSize || captureHeight > maxSize))
                 {
                     var scale = Math.Min((float)maxSize / captureWidth, (float)maxSize / captureHeight);
                     captureWidth = Mathf.Max(1, Mathf.RoundToInt(captureWidth * scale));
@@ -277,7 +297,18 @@ namespace UnityMCP.Editor.Handlers
                         400);
                 }
 
-                if (targetWidth > maxSize || targetHeight > maxSize)
+                if (targetWidth > MaxRequestedEdge || targetHeight > MaxRequestedEdge)
+                {
+                    throw new McpScreenshotException(
+                        "invalid_params",
+                        $"width and height are capped at {MaxRequestedEdge}. A picture costs a "
+                        + "model by its area, and this one would be larger than any view of it needs.",
+                        400);
+                }
+
+                var askedForSize = requestedWidth.HasValue || requestedHeight.HasValue;
+
+                if (!askedForSize && (targetWidth > maxSize || targetHeight > maxSize))
                 {
                     var scale = Math.Min((float)maxSize / targetWidth, (float)maxSize / targetHeight);
                     targetWidth = Mathf.Max(1, Mathf.RoundToInt(targetWidth * scale));

--- a/jp.shiranui-isuzu.unity-mcp/Editor/TestRunner/TestRunnerTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/TestRunner/TestRunnerTools.cs
@@ -272,7 +272,9 @@ namespace UnityMCP.Editor.TestRunner
                     ["status"] = result.TestStatus.ToString().ToLowerInvariant(),
                     ["durationSeconds"] = result.Duration,
                     ["message"] = string.IsNullOrEmpty(result.Message) ? null : result.Message,
-                    ["stackTrace"] = string.IsNullOrEmpty(result.StackTrace) ? null : result.StackTrace,
+                    ["stackTrace"] = string.IsNullOrEmpty(result.StackTrace)
+                        ? null
+                        : LogNoise.TrimStack(result.StackTrace),
                 };
 
                 yield break;

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/InspectorAccessTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/InspectorAccessTests.cs
@@ -1,0 +1,120 @@
+using System.Linq;
+
+using Newtonsoft.Json.Linq;
+
+using NUnit.Framework;
+
+using UnityEngine;
+
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Handlers;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// inspect_read, inspect_write and inspect_list share one handler. The components view belongs
+    /// to a listing alone: reached from a write it changes nothing and answers with a component
+    /// list, which reads as a result rather than as a failure.
+    /// </summary>
+    public sealed class InspectorAccessTests
+    {
+        private GameObject target;
+
+        [SetUp]
+        public void SetUp()
+        {
+            target = new GameObject("InspectorAccessTests");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (target != null)
+            {
+                Object.DestroyImmediate(target);
+            }
+        }
+
+        [Test]
+        public void AWriteWithNoComponentNamedChangesTheGameObject()
+        {
+            var reply = InspectorAccess.Access(ToolArgs.Of(
+                ("mode", "write"),
+                ("objectPath", "/InspectorAccessTests"),
+                ("propertyPath", "m_Name"),
+                ("value", "Renamed")));
+
+            Assert.That(reply["error"], Is.Null, "the write must not report a failure");
+            Assert.That(reply["written"], Is.Not.Null, "a listing came back instead of a write");
+            Assert.That(target.name, Is.EqualTo("Renamed"), "the object itself has to change");
+        }
+
+        [Test]
+        public void AReadWithNoComponentNamedReadsTheGameObject()
+        {
+            var reply = InspectorAccess.Access(ToolArgs.Of(
+                ("mode", "read"),
+                ("objectPath", "/InspectorAccessTests"),
+                ("propertyPath", "m_Name")));
+
+            Assert.That(reply["property"]?["value"]?.ToString(), Is.EqualTo("InspectorAccessTests"));
+        }
+
+        /// <summary>Only a listing asks for the components view, and only when none is named.</summary>
+        [Test]
+        public void AListWithNoComponentNamedStillListsComponents()
+        {
+            var reply = InspectorAccess.Access(ToolArgs.Of(
+                ("mode", "list"),
+                ("objectPath", "/InspectorAccessTests")));
+
+            Assert.That(reply["components"], Is.Not.Null);
+        }
+
+        /// <summary>
+        /// The schema offers offset and limit whichever way the tool is called, so naming a
+        /// component cannot silently return every property.
+        /// </summary>
+        [Test]
+        public void NamingAComponentStillHonoursTheLimit()
+        {
+            var all = InspectorAccess.Access(ToolArgs.Of(
+                ("mode", "list"),
+                ("objectPath", "/InspectorAccessTests"),
+                ("componentType", "Transform")));
+
+            var paged = InspectorAccess.Access(ToolArgs.Of(
+                ("mode", "list"),
+                ("objectPath", "/InspectorAccessTests"),
+                ("componentType", "Transform"),
+                ("limit", 2)));
+
+            Assert.That(paged["properties"].Children().Count(), Is.EqualTo(2));
+            Assert.That(all["properties"].Children().Count(), Is.GreaterThan(2),
+                "the fixture needs more properties than the page for this to prove anything");
+            Assert.That(paged["truncated"].Value<bool>(), Is.True);
+            Assert.That(paged["count"].Value<int>(), Is.EqualTo(all["count"].Value<int>()),
+                "a page still reports how many there were");
+        }
+
+        [Test]
+        public void AnOffsetSkipsProperties()
+        {
+            var first = InspectorAccess.Access(ToolArgs.Of(
+                ("mode", "list"),
+                ("objectPath", "/InspectorAccessTests"),
+                ("componentType", "Transform"),
+                ("limit", 1)));
+
+            var second = InspectorAccess.Access(ToolArgs.Of(
+                ("mode", "list"),
+                ("objectPath", "/InspectorAccessTests"),
+                ("componentType", "Transform"),
+                ("offset", 1),
+                ("limit", 1)));
+
+            Assert.That(second["properties"][0]["path"].ToString(),
+                Is.Not.EqualTo(first["properties"][0]["path"].ToString()));
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/InspectorAccessTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/InspectorAccessTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86f1e33557ba552469dd49ff03d6cf83

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ListResponseBuilderTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ListResponseBuilderTests.cs
@@ -118,6 +118,77 @@ namespace UnityMCP.Editor.Tests
             Assert.IsFalse(result["truncated"].Value<bool>());
         }
 
+
+        // ── the fields allowlist ──
+
+        private static JObject Row(int n) => new JObject
+        {
+            ["id"] = n,
+            ["name"] = "row" + n,
+        };
+
+        private static JObject RowWithOptional(int n)
+        {
+            var row = Row(n);
+
+            // Written on one row only, the way a field omitted at its default value behaves.
+            // Assigning null would still create the key, which is not the same thing.
+            if (n == 2)
+            {
+                row["note"] = "seen";
+            }
+
+            return row;
+        }
+
+        private static readonly IReadOnlyList<int> Three = new[] { 1, 2, 3 };
+
+        /// <summary>
+        /// A field the tool keeps on its own travels back, but it is not the caller's name, so it
+        /// cannot stand in for their list having matched something.
+        /// </summary>
+        [Test]
+        public void AFieldTheToolKeepsIsReturnedButDoesNotCountAsAMatch()
+        {
+            var page = ListResponseBuilder.Build(Three, 0, 0, Row, new[] { "name" }, new[] { "id" });
+            var first = (JObject)((JArray)page["items"])[0];
+
+            Assert.IsNotNull(first["name"]);
+            Assert.IsNotNull(first["id"], "the tool's own field travels whatever was asked for");
+        }
+
+        /// <summary>
+        /// Answering with empty objects let a caller narrow a reply to nothing and read it as an
+        /// empty result.
+        /// </summary>
+        [Test]
+        public void ANameThatMatchesNothingIsRefusedEvenWhenTheToolKeepsItsOwnField()
+        {
+            var thrown = Assert.Throws<McpToolException>(
+                () => ListResponseBuilder.Build(Three, 0, 0, Row, new[] { "nonesuch" }, new[] { "id" }));
+
+            Assert.AreEqual("invalid_params", thrown.Code);
+        }
+
+        /// <summary>A row omitting an optional field says nothing about whether the tool has it.</summary>
+        [Test]
+        public void ANameOnlySomeRowsCarryIsAccepted()
+        {
+            var page = ListResponseBuilder.Build(Three, 0, 0, RowWithOptional, new[] { "note" });
+            var rows = (JArray)page["items"];
+            var carrying = 0;
+
+            foreach (JObject row in rows)
+            {
+                if (row["note"] != null)
+                {
+                    carrying++;
+                }
+            }
+
+            Assert.AreEqual(1, carrying);
+        }
+
         [Test]
         public void ParseFieldsParam_HandlesNullAndWhitespaceAsNoFilter()
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/LogNoiseTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/LogNoiseTests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using UnityMCP.Editor.Core;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// A stack trace is mostly the machinery that reached the failure, and an Editor log is mostly
+    /// the asset pipeline narrating itself. Both are re-sent to a model on every later turn, so
+    /// what survives the cut decides whether the reader can act on the reply at all.
+    /// </summary>
+    public sealed class LogNoiseTests
+    {
+        private static readonly string[] NUnitTrace =
+        {
+            "ConsoleFilterTests: a warning that survives the Log toggle.",
+            "UnityEngine.Debug:LogWarning (object)",
+            "UnityMCP.Editor.Tests.ConsoleFilterTests:TheCountsAgree () " +
+            "(at H:/PublicGithub/UnityMCP/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ConsoleFilterTests.cs:182)",
+            "System.Reflection.MethodBase:Invoke (object,object[])",
+            "NUnit.Framework.Internal.Reflect:InvokeMethod (System.Reflection.MethodInfo,object,object[])",
+            "NUnit.Framework.Internal.MethodWrapper:Invoke (object,object[])",
+            "NUnit.Framework.Internal.Commands.TestMethodCommand:Execute (NUnit.Framework.Internal.ITestExecutionContext)",
+            "UnityEditor.EditorApplication:Internal_CallUpdateFunctions ()",
+        };
+
+        [Test]
+        public void TheFrameNamingSourceSurvivesAndTheMachineryIsCounted()
+        {
+            var kept = LogNoise.TrimStacks(NUnitTrace);
+
+            Assert.That(kept[0], Is.EqualTo(NUnitTrace[0]), "the message is the point of the entry");
+            Assert.That(kept[1], Does.Contain("ConsoleFilterTests:TheCountsAgree"));
+            Assert.That(kept[1], Does.Contain(":182"), "a frame without its line cannot be opened");
+            Assert.That(kept[kept.Count - 1], Does.Match(@"^\s*\(\+6 frames via "));
+            Assert.That(kept, Has.Count.EqualTo(3));
+        }
+
+        /// <summary>
+        /// The path is the same machine and package root on every frame of every entry, and three
+        /// segments still name the file.
+        /// </summary>
+        [Test]
+        public void ALocationIsCutBackToItsLastSegments()
+        {
+            var kept = LogNoise.TrimStacks(NUnitTrace);
+
+            Assert.That(kept[1], Does.Contain("(at Editor/Tests/ConsoleFilterTests.cs:182)"));
+            Assert.That(kept[1], Does.Not.Contain("H:/PublicGithub"));
+        }
+
+        /// <summary>
+        /// Mono prints generated thunks between real frames. A line the walk does not recognise
+        /// ends the run, and each half then keeps its own quota, so the trace comes back twice
+        /// the size it should.
+        /// </summary>
+        [Test]
+        public void AGeneratedThunkDoesNotSplitTheTrace()
+        {
+            var trace = new List<string>
+            {
+                "boom",
+                "A.B:C () (at Assets/Scripts/A.cs:1)",
+                "(wrapper dynamic-method) object:lambda_method (System.Runtime.CompilerServices.Closure)",
+                "D.E:F () (at Assets/Scripts/D.cs:2)",
+                "NUnit.Framework.Internal.MethodWrapper:Invoke (object,object[])",
+            };
+
+            var kept = LogNoise.TrimStacks(trace);
+
+            Assert.That(kept, Has.Count.EqualTo(4), "one message, two located frames, one note");
+            Assert.That(kept[3], Does.Contain("(+2 frames"), "the thunk names no source either");
+        }
+
+        /// <summary>
+        /// An engine-side failure names no source. Dropping every frame would leave the reader
+        /// with nothing at all, so the top of the stack stands in.
+        /// </summary>
+        [Test]
+        public void ATraceNamingNoSourceKeepsItsTopFrames()
+        {
+            var trace = new List<string>
+            {
+                "crashed",
+                "UnityEngine.Rendering.CommandBuffer:DrawMesh (UnityEngine.Mesh,UnityEngine.Matrix4x4)",
+                "UnityEngine.Rendering.ScriptableRenderContext:Submit ()",
+                "UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&)",
+                "UnityEditor.DockArea:OnGUI ()",
+            };
+
+            var kept = LogNoise.TrimStacks(trace);
+
+            Assert.That(kept[1], Does.Contain("CommandBuffer:DrawMesh"));
+            Assert.That(kept, Has.Count.EqualTo(5), "three frames stand in, plus the message and the note");
+        }
+
+        [Test]
+        public void AlikeLinesFoldToTheFirstOneWithACount()
+        {
+            var lines = new List<string>
+            {
+                "Asset Pipeline Refresh (id=aabbccddeeff0011): Total: 0.011 seconds",
+                "Asset Pipeline Refresh (id=1122334455667788): Total: 0.014 seconds",
+                "Asset Pipeline Refresh (id=99aabbccddeeff00): Total: 0.009 seconds",
+                "something else",
+            };
+
+            var folded = LogNoise.FoldRepeats(lines, out var hidden);
+
+            Assert.That(hidden, Is.EqualTo(2));
+            Assert.That(folded, Has.Count.EqualTo(2));
+            Assert.That(folded[0], Does.StartWith(lines[0]), "the first is kept whole, not turned into a pattern");
+            Assert.That(folded[0], Does.Contain("[and 2 more like it]"));
+        }
+
+        /// <summary>Two failures differing only by a number are two failures, not one repeated.</summary>
+        [Test]
+        public void LinesReportingAProblemAreNeverFolded()
+        {
+            var lines = new List<string>
+            {
+                "error CS0103: The name 'a1' does not exist",
+                "error CS0103: The name 'a2' does not exist",
+                "error CS0103: The name 'a3' does not exist",
+            };
+
+            var folded = LogNoise.FoldRepeats(lines, out var hidden);
+
+            Assert.That(hidden, Is.Zero);
+            Assert.That(folded, Is.EqualTo(lines));
+        }
+
+        [Test]
+        public void ALineOnItsOwnIsLeftAlone()
+        {
+            Assert.That(LogNoise.TrimStack("just a message"), Is.EqualTo("just a message"));
+            Assert.That(LogNoise.TrimStack(null), Is.Null);
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/LogNoiseTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/LogNoiseTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 120542dcd4f628c46a934332163d0e72

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/LogReaderTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/LogReaderTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using UnityMCP.Editor.Core;
 using UnityMCP.Editor.Handlers;
 
 namespace UnityMCP.Editor.Tests
@@ -47,5 +48,22 @@ namespace UnityMCP.Editor.Tests
                     $"bit {bit} ({mode}) is classified differently from the Editor's own set");
             }
         }
+
+        /// <summary>
+        /// The filter compares against four names. One that matches none of them narrows nothing,
+        /// so a caller asking for "ERROR" is handed every log line and reads it as the errors.
+        /// </summary>
+        [TestCase("ERROR")]
+        [TestCase("errors")]
+        [TestCase("fatal")]
+        public void ASeverityTheFilterDoesNotKnowIsRefused(string severity)
+        {
+            var thrown = Assert.Throws<McpToolException>(
+                () => LogReader.ReadLogs(ToolArgs.Of(("type", severity))));
+
+            Assert.That(thrown.Code, Is.EqualTo("invalid_params"));
+            Assert.That(thrown.Message, Does.Contain("all, error, warning or log"));
+        }
+
     }
 }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/McpStreamableHttpEndpointTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/McpStreamableHttpEndpointTests.cs
@@ -35,6 +35,19 @@ namespace UnityMCP.Editor.Tests
                 ["image"] = "iVBORw0KGgpyZXN0",
             };
 
+            [McpTool("ep_shot_nested", "A capture beside other work.", Idempotency = McpIdempotency.Safe, MainThread = false)]
+            public static JObject ShotNested() => new JObject
+            {
+                ["sent"] = 2,
+                ["window"] = "Game",
+                ["capture"] = new JObject
+                {
+                    ["view"] = "game",
+                    ["width"] = 2,
+                    ["image"] = "iVBORw0KGgpyZXN0",
+                },
+            };
+
             [McpTool("ep_refused", "Reports failure the handler way.", Idempotency = McpIdempotency.Safe, MainThread = false)]
             public static JObject Refused() => new JObject { ["error"] = "No active scene view found" };
 
@@ -105,8 +118,38 @@ namespace UnityMCP.Editor.Tests
             Assert.That(content[1]["data"].Value<string>(), Is.EqualTo("iVBORw0KGgpyZXN0"));
             Assert.That(content[1]["mimeType"].Value<string>(), Is.EqualTo("image/png"));
 
-            Assert.That(result["structuredContent"]["image"], Is.Not.Null,
-                "the structured copy keeps it for callers that read the field");
+            Assert.That(result["structuredContent"]["image"], Is.Null,
+                "keeping it here sent the same picture twice, once priced by size and once by area");
+            Assert.That(result["structuredContent"]["width"], Is.Not.Null,
+                "everything else about the capture still belongs in the structured copy");
+        }
+
+        /// <summary>
+        /// A tool that captures alongside other work puts the PNG under its own key. Looking only
+        /// at the top and at "result" meant input_replay shipped a screenshot as a text block.
+        /// </summary>
+        [Test]
+        public void ACaptureIsFoundWhereverTheToolPutIt()
+        {
+            var response = this.Post(Request(1, "tools/call", new JObject
+            {
+                ["name"] = "ep_shot_nested",
+                ["arguments"] = new JObject(),
+            }));
+
+            var result = response.Body["result"];
+            var content = (JArray)result["content"];
+
+            Assert.That(content.Count, Is.EqualTo(2));
+            Assert.That(content[0]["text"].Value<string>(), Does.Not.Contain("iVBORw0KGgpyZXN0"));
+            Assert.That(content[0]["text"].Value<string>(), Does.Contain("sent"),
+                "the rest of the reply is what the caller asked for");
+            Assert.That(content[1]["type"].Value<string>(), Is.EqualTo("image"));
+            Assert.That(content[1]["data"].Value<string>(), Is.EqualTo("iVBORw0KGgpyZXN0"));
+
+            Assert.That(result["structuredContent"]["capture"]["image"], Is.Null);
+            Assert.That(result["structuredContent"]["capture"]["view"].Value<string>(),
+                Is.EqualTo("game"));
         }
 
         /// <summary>
@@ -305,7 +348,7 @@ namespace UnityMCP.Editor.Tests
             var response = this.Post(Request(1, "tools/list"));
 
             var tools = ToolsOf(response);
-            Assert.That(tools.Select(t => t["name"].Value<string>()), Is.EquivalentTo(new[] { "ep_echo", "ep_delete", "ep_shot", "ep_refused", "ep_job_detail", "ep_shot_job" }));
+            Assert.That(tools.Select(t => t["name"].Value<string>()), Is.EquivalentTo(new[] { "ep_echo", "ep_delete", "ep_shot", "ep_shot_nested", "ep_refused", "ep_job_detail", "ep_shot_job" }));
 
             var echo = tools.Single(t => t["name"].Value<string>() == "ep_echo");
             Assert.That(echo["annotations"]["readOnlyHint"].Value<bool>(), Is.True);

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ReflectSerializeTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ReflectSerializeTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using UnityMCP.Editor.Tools;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// depth bounds how deep a reflection walk goes and max_items how wide each level is. They
+    /// multiply, so a value either one allows on its own can still be the product of the two, and
+    /// a reply built from it stays in the conversation for the rest of the session.
+    /// </summary>
+    public sealed class ReflectSerializeTests
+    {
+        private sealed class Node
+        {
+            public Node A;
+            public Node B;
+            public Node C;
+            public int Leaf;
+        }
+
+        private static Node Chain(int deep)
+        {
+            var node = new Node { Leaf = deep };
+
+            if (deep > 0)
+            {
+                node.A = Chain(deep - 1);
+                node.B = Chain(deep - 1);
+                node.C = Chain(deep - 1);
+            }
+
+            return node;
+        }
+
+        /// <summary>A back-reference re-expands its subtree at every level that is left.</summary>
+        private sealed class Loop
+        {
+            public Loop Self;
+            public int Value;
+        }
+
+        /// <summary>A wide level costs as much as a deep one, and only the budget counts both.</summary>
+        [Test]
+        public void AWideWalkStopsAtTheNodeBudget()
+        {
+            var wide = new List<List<int>>();
+
+            for (var i = 0; i < 300; i++)
+            {
+                var inner = new List<int>();
+                for (var k = 0; k < 300; k++)
+                {
+                    inner.Add(k);
+                }
+
+                wide.Add(inner);
+            }
+
+            var text = ReflectTools.Serialize(wide, 99, 99).ToString(Newtonsoft.Json.Formatting.None);
+
+            Assert.That(text, Does.Contain("\"truncated\":\"budget\""),
+                "depth says nothing about how wide a level is");
+            Assert.That(text.Length, Is.LessThan(400_000),
+                "the budget has to hold the reply to something a reader can carry");
+        }
+
+        /// <summary>A caller asking for more than the ceiling gets the ceiling, not the ask.</summary>
+        [Test]
+        public void DepthAndItemCountAreClampedNotObeyed()
+        {
+            var wild = ReflectTools.Serialize(Chain(9), 99, 99).ToString(Newtonsoft.Json.Formatting.None);
+            var sane = ReflectTools.Serialize(Chain(9), 4, 200).ToString(Newtonsoft.Json.Formatting.None);
+
+            Assert.That(wild.Length, Is.EqualTo(sane.Length));
+        }
+
+        [Test]
+        public void ACycleTerminates()
+        {
+            var loop = new Loop { Value = 1 };
+            loop.Self = loop;
+
+            Assert.That(
+                () => ReflectTools.Serialize(loop, 99, 99),
+                Throws.Nothing,
+                "depth and the budget both have to hold, or a back-reference runs until the stack gives out");
+        }
+
+        [Test]
+        public void ALongStringIsCutAndSaysHowLongItWas()
+        {
+            var serialized = ReflectTools.Serialize(new string('x', 12_000), 2, 20).ToString();
+
+            Assert.That(serialized.Length, Is.LessThan(5_000));
+            Assert.That(serialized, Does.Contain("12000 characters"));
+        }
+
+        [Test]
+        public void AShortStringIsLeftAlone()
+        {
+            Assert.That(ReflectTools.Serialize("hello", 2, 20).ToString(), Is.EqualTo("hello"));
+        }
+
+        [Test]
+        public void ACollectionStillReportsThatItWasCut()
+        {
+            var many = new List<int>();
+            for (var i = 0; i < 500; i++)
+            {
+                many.Add(i);
+            }
+
+            var text = ReflectTools.Serialize(many, 2, 5).ToString(Newtonsoft.Json.Formatting.None);
+
+            Assert.That(text, Does.Contain("more than 5"));
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ReflectSerializeTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/ReflectSerializeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9bb7b8f36f96f32469ab1a374ecc05c0

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/RequiredArgumentTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/RequiredArgumentTests.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+
+using NUnit.Framework;
+
+using UnityMCP.Editor.Core;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// An argument written with a C# default is optional in the schema, and an agent reads the
+    /// schema to decide what to send. Where the handler then refuses the call, every omission is a
+    /// refused round trip that the agent had no way to foresee.
+    /// </summary>
+    /// <remarks>
+    /// The C# default cannot simply be removed: these parameters are followed by other defaulted
+    /// ones, so <c>[McpArg(Required = true)]</c> is what puts them back in the schema's
+    /// <c>required</c> array.
+    /// </remarks>
+    public sealed class RequiredArgumentTests
+    {
+        private static readonly (string Tool, string Argument)[] Refused =
+        {
+            ("asset_info", "path"),
+            ("asset_create_folder", "path"),
+            ("asset_move", "path"),
+            ("asset_move", "destination"),
+            ("asset_delete", "path"),
+            ("asset_reimport", "path"),
+            ("reflect_read", "path"),
+            ("reflect_find_type", "name"),
+            ("render_compare", "before"),
+            ("render_compare", "after"),
+            ("build_player", "output_path"),
+            ("scene_open", "path"),
+            ("prefab_create", "path"),
+            ("prefab_instantiate", "path"),
+            ("gameobject_add_component", "component_type"),
+            ("gameobject_remove_component", "component_type"),
+            ("input_pointer", "from"),
+            ("animator_add_layer", "name"),
+            ("animator_remove_layer", "layer"),
+            ("animator_add_state", "layer"),
+            ("animator_add_state", "name"),
+            ("animator_remove_state", "layer"),
+            ("animator_remove_state", "state"),
+            ("animator_set_state", "layer"),
+            ("animator_set_state", "state"),
+            ("animator_add_transition", "layer"),
+            ("animator_add_transition", "to_state"),
+            ("animator_remove_transition", "layer"),
+            ("animator_add_parameter", "name"),
+            ("animator_remove_parameter", "name"),
+            ("timeline_create", "asset_path"),
+            ("timeline_create_track", "type"),
+            ("timeline_create_clip", "track"),
+            ("timeline_edit_clip", "track"),
+            ("timeline_set_track", "track"),
+            ("timeline_delete", "track"),
+        };
+
+        /// <summary>
+        /// Arguments a handler wants only in some situations. Marking one of these required would
+        /// refuse a call that works — a drag needs 'to', a move does not.
+        /// </summary>
+        private static readonly (string Tool, string Argument)[] Conditional =
+        {
+            ("material_set", "value"),
+            ("material_read", "slot"),
+            ("material_set", "slot"),
+            ("input_pointer", "to"),
+            ("input_pointer", "scroll_delta"),
+        };
+
+        private static ToolCatalog catalog;
+
+        [OneTimeSetUp]
+        public void BuildCatalog()
+        {
+            catalog = ToolCatalog.Build();
+        }
+
+        private static string[] RequiredOf(string tool)
+        {
+            var descriptor = catalog.Tools.FirstOrDefault(t => t.Name == tool);
+            Assert.That(descriptor, Is.Not.Null, $"'{tool}' is not in the catalog.");
+
+            return descriptor.InputSchema["required"]?.Select(t => t.ToString()).ToArray()
+                   ?? new string[0];
+        }
+
+        [Test]
+        public void EveryArgumentAHandlerRefusesToWorkWithoutIsDeclaredRequired()
+        {
+            foreach (var (tool, argument) in Refused)
+            {
+                var required = RequiredOf(tool);
+
+                Assert.That(required, Does.Contain(argument),
+                    $"'{tool}' refuses the call without '{argument}', so the schema has to say so.");
+            }
+        }
+
+        [Test]
+        public void AnArgumentWantedOnlySometimesIsNotDeclaredRequired()
+        {
+            foreach (var (tool, argument) in Conditional)
+            {
+                var required = RequiredOf(tool);
+
+                Assert.That(required, Does.Not.Contain(argument),
+                    $"'{argument}' is wanted only in some situations, so requiring it refuses calls that work.");
+            }
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/RequiredArgumentTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/RequiredArgumentTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce6aba5ac01cbc64a8b8edc026da2439

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineCreateTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineCreateTools.cs
@@ -56,7 +56,7 @@ namespace UnityMCP.Editor.Timeline
             Idempotency = McpIdempotency.Unsafe,
             UndoGroup = "MCP Create Timeline")]
         public static JObject Create(
-            [McpArg("asset_path", "Where to write the .playable, e.g. 'Assets/Stage/Stage.playable'.")]
+            [McpArg("asset_path", "Where to write the .playable, e.g. 'Assets/Stage/Stage.playable'.", Required = true)]
             string assetPath = null,
             [McpArg("frame_rate", "Timeline frame rate. Recorder takes its capture rate from this.")]
             double frameRate = 60,
@@ -167,7 +167,7 @@ namespace UnityMCP.Editor.Timeline
             string objectPath = null,
             [McpArg("instance_id", "Address the director's GameObject by instance id instead.")]
             long? instanceId = null,
-            [McpArg("type", "Track type: activation, animation, audio, control, group, playable or signal.")]
+            [McpArg("type", "Track type: activation, animation, audio, control, group, playable or signal.", Required = true)]
             string type = null,
             [McpArg("name", "Name for the track. Timeline makes it unique among its siblings.")]
             string name = null,
@@ -282,7 +282,7 @@ namespace UnityMCP.Editor.Timeline
             string objectPath = null,
             [McpArg("instance_id", "Address the director's GameObject by instance id instead.")]
             long? instanceId = null,
-            [McpArg("track", "Track path to add the clip to, as timeline_inspect reports it.")]
+            [McpArg("track", "Track path to add the clip to, as timeline_inspect reports it.", Required = true)]
             string track = null,
             [McpArg("start", "Clip start on the timeline, in seconds.")]
             double start = 0,

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineEditTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineEditTools.cs
@@ -53,7 +53,7 @@ namespace UnityMCP.Editor.Timeline
             string objectPath = null,
             [McpArg("instance_id", "Address the director's GameObject by instance id instead.")]
             long? instanceId = null,
-            [McpArg("track", "Track path, as timeline_inspect reports it, e.g. 'Cameras/CamFront'.")]
+            [McpArg("track", "Track path, as timeline_inspect reports it, e.g. 'Cameras/CamFront'.", Required = true)]
             string track = null,
             [McpArg("clip", "Display name of the clip to edit.")]
             string clip = null,

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineTools.cs
@@ -238,7 +238,7 @@ namespace UnityMCP.Editor.Timeline
                 if (includeClips || IsControlTrack(t))
                 {
                     entry["clips"] = new JArray(t.GetClips()
-                        .Select(c => (object)DescribeClip(c, director, nestDepth, visited))
+                        .Select(c => (object)DescribeClip(c, director, includeClips, nestDepth, visited))
                         .ToArray());
                 }
 
@@ -252,7 +252,7 @@ namespace UnityMCP.Editor.Timeline
         }
 
         private static JObject DescribeClip(
-            TimelineClip clip, PlayableDirector director, int nestDepth, HashSet<long> visited)
+            TimelineClip clip, PlayableDirector director, bool includeClips, int nestDepth, HashSet<long> visited)
         {
             var entry = new JObject
             {
@@ -283,8 +283,11 @@ namespace UnityMCP.Editor.Timeline
 
                         if (nestDepth > 0)
                         {
+                            // includeClips travels: a caller who asked for no clips meant
+                            // this timeline too. The track filter does not, because it names
+                            // tracks in the timeline the caller asked about, not in this one.
                             entry["nested"] = DescribeDirector(
-                                childDirector, true, null, nestDepth - 1, visited);
+                                childDirector, includeClips, null, nestDepth - 1, visited);
                         }
                         else
                         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineTrackTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Timeline/TimelineTrackTools.cs
@@ -43,7 +43,7 @@ namespace UnityMCP.Editor.Timeline
             string objectPath = null,
             [McpArg("instance_id", "Address the director's GameObject by instance id instead.")]
             long? instanceId = null,
-            [McpArg("track", "Track path, as timeline_inspect reports it, e.g. 'Cameras/CamFront'.")]
+            [McpArg("track", "Track path, as timeline_inspect reports it, e.g. 'Cameras/CamFront'.", Required = true)]
             string track = null,
             [McpArg("muted", "Mute or unmute the track. A muted track is left out of the timeline's length.")]
             bool? muted = null,
@@ -173,7 +173,7 @@ namespace UnityMCP.Editor.Timeline
             string objectPath = null,
             [McpArg("instance_id", "Address the director's GameObject by instance id instead.")]
             long? instanceId = null,
-            [McpArg("track", "Track path. Without a clip argument, the track itself is deleted.")]
+            [McpArg("track", "Track path. Without a clip argument, the track itself is deleted.", Required = true)]
             string track = null,
             [McpArg("clip", "Display name of a clip to delete, leaving the track in place.")]
             string clip = null,

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AnimatorEditTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AnimatorEditTools.cs
@@ -63,7 +63,7 @@ namespace UnityMCP.Editor.Tools
                                    "controller, instead of naming the asset.")]
             string objectPath = null,
             [McpArg("name", "Name for the new layer. Nothing stops two layers sharing a name; " +
-                            "animator_audit reports it when they do.")]
+                            "animator_audit reports it when they do.", Required = true)]
             string name = null,
             [McpArg("weight", "Default weight, 0 to 1.")]
             float weight = 1f,
@@ -148,7 +148,7 @@ namespace UnityMCP.Editor.Tools
             string path = null,
             [McpArg("object_path", "Hierarchy path of a GameObject that points at the controller.")]
             string objectPath = null,
-            [McpArg("layer", "Layer to remove, by name or by index.")]
+            [McpArg("layer", "Layer to remove, by name or by index.", Required = true)]
             string layer = null)
         {
             var controller = AnimatorResolve.Controller(path, objectPath);
@@ -191,9 +191,9 @@ namespace UnityMCP.Editor.Tools
             string path = null,
             [McpArg("object_path", "Hierarchy path of a GameObject that points at the controller.")]
             string objectPath = null,
-            [McpArg("layer", "Layer to add to, by name or by index.")]
+            [McpArg("layer", "Layer to add to, by name or by index.", Required = true)]
             string layer = null,
-            [McpArg("name", "Name for the new state.")]
+            [McpArg("name", "Name for the new state.", Required = true)]
             string name = null,
             [McpArg("motion", "AnimationClip asset path for the state to play. Omit for an empty state.")]
             string motion = null,
@@ -269,10 +269,10 @@ namespace UnityMCP.Editor.Tools
             string path = null,
             [McpArg("object_path", "Hierarchy path of a GameObject that points at the controller.")]
             string objectPath = null,
-            [McpArg("layer", "Layer holding the state, by name or by index.")]
+            [McpArg("layer", "Layer holding the state, by name or by index.", Required = true)]
             string layer = null,
             [McpArg("state", "State to remove, by name, or by path when it sits in a sub-state " +
-                             "machine, e.g. 'Gestures/Point'.")]
+                             "machine, e.g. 'Gestures/Point'.", Required = true)]
             string state = null)
         {
             var controller = AnimatorResolve.Controller(path, objectPath);
@@ -315,9 +315,9 @@ namespace UnityMCP.Editor.Tools
             string path = null,
             [McpArg("object_path", "Hierarchy path of a GameObject that points at the controller.")]
             string objectPath = null,
-            [McpArg("layer", "Layer holding the state, by name or by index.")]
+            [McpArg("layer", "Layer holding the state, by name or by index.", Required = true)]
             string layer = null,
-            [McpArg("state", "State to change, by name or by path within the layer.")]
+            [McpArg("state", "State to change, by name or by path within the layer.", Required = true)]
             string state = null,
             [McpArg("motion", "AnimationClip asset path to play. Pass an empty string to clear the " +
                               "motion and leave the state empty.")]
@@ -516,12 +516,12 @@ namespace UnityMCP.Editor.Tools
             string path = null,
             [McpArg("object_path", "Hierarchy path of a GameObject that points at the controller.")]
             string objectPath = null,
-            [McpArg("layer", "Layer holding both states, by name or by index.")]
+            [McpArg("layer", "Layer holding both states, by name or by index.", Required = true)]
             string layer = null,
             [McpArg("from_state", "Source state, by name or by path. Omit to make it an Any State " +
                                   "transition, which can fire from anywhere in the layer.")]
             string fromState = null,
-            [McpArg("to_state", "Destination state, by name or by path.")]
+            [McpArg("to_state", "Destination state, by name or by path.", Required = true)]
             string toState = null,
             [McpArg("conditions", "Array of {parameter, mode, threshold}. Modes: If and IfNot for a " +
                                   "bool or trigger, Greater and Less for a float or int, Equals and " +
@@ -608,7 +608,7 @@ namespace UnityMCP.Editor.Tools
             string path = null,
             [McpArg("object_path", "Hierarchy path of a GameObject that points at the controller.")]
             string objectPath = null,
-            [McpArg("layer", "Layer holding the transition, by name or by index.")]
+            [McpArg("layer", "Layer holding the transition, by name or by index.", Required = true)]
             string layer = null,
             [McpArg("from_state", "Source state, by name or by path. Omit to remove one of the layer's " +
                                   "Any State transitions.")]
@@ -676,7 +676,7 @@ namespace UnityMCP.Editor.Tools
             [McpArg("object_path", "Hierarchy path of a GameObject that points at the controller.")]
             string objectPath = null,
             [McpArg("name", "Parameter name. Names are case sensitive and a condition matches on the " +
-                            "exact string.")]
+                            "exact string.", Required = true)]
             string name = null,
             [McpArg("type", "'Float', 'Int', 'Bool' or 'Trigger'.")]
             string type = "Float",
@@ -736,7 +736,7 @@ namespace UnityMCP.Editor.Tools
             string path = null,
             [McpArg("object_path", "Hierarchy path of a GameObject that points at the controller.")]
             string objectPath = null,
-            [McpArg("name", "Parameter to remove. Case sensitive.")]
+            [McpArg("name", "Parameter to remove. Case sensitive.", Required = true)]
             string name = null)
         {
             if (string.IsNullOrWhiteSpace(name))

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AnimatorInspectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AnimatorInspectTools.cs
@@ -21,6 +21,19 @@ namespace UnityMCP.Editor.Tools
     /// </remarks>
     internal static class AnimatorInspectTools
     {
+        /// <summary>
+        /// States reported from one layer. A layer holds its sub-state machines too, and each
+        /// state brings its transitions and their conditions, so a rig's FX layer runs to hundreds.
+        /// </summary>
+        private const int MaxStates = 120;
+
+        /// <summary>
+        /// Transitions reported per state, and from Any State. A layer's size has two axes, and
+        /// capping the states alone leaves this one free: six transitions on each of a hundred
+        /// states is six hundred entries.
+        /// </summary>
+        private const int MaxTransitions = 24;
+
         [McpTool(
             "animator_inspect",
             "Read an Animator Controller. Name the asset with 'path', or name a scene object with " +
@@ -153,9 +166,17 @@ namespace UnityMCP.Editor.Tools
             var defaultState = machine.defaultState;
 
             var states = new JArray();
+            var stateTotal = 0;
 
             foreach (var entry in AnimatorResolve.States(machine))
             {
+                // A layer is not a small unit: sub-state machines are walked too, and every state
+                // carries its transitions and their conditions.
+                if (++stateTotal > MaxStates)
+                {
+                    continue;
+                }
+
                 var state = entry.State;
 
                 var projected = new JObject
@@ -188,16 +209,33 @@ namespace UnityMCP.Editor.Tools
                 }
 
                 projected["transitions"] = new JArray(
-                    state.transitions.Select((t, i) => (object)AnimatorResolve.Transition(t, i, addressOf)).ToArray());
+                    state.transitions.Take(MaxTransitions)
+                        .Select((t, i) => (object)AnimatorResolve.Transition(t, i, addressOf)).ToArray());
+
+                if (state.transitions.Length > MaxTransitions)
+                {
+                    projected["transitionCount"] = state.transitions.Length;
+                }
 
                 states.Add(projected);
             }
 
-            result["stateCount"] = states.Count;
+            result["stateCount"] = stateTotal;
             result["states"] = states;
 
+            if (stateTotal > MaxStates)
+            {
+                result["truncated"] = $"{stateTotal} states in this layer";
+            }
+
             result["anyStateTransitions"] = new JArray(
-                machine.anyStateTransitions.Select((t, i) => (object)AnimatorResolve.Transition(t, i, addressOf)).ToArray());
+                machine.anyStateTransitions.Take(MaxTransitions)
+                    .Select((t, i) => (object)AnimatorResolve.Transition(t, i, addressOf)).ToArray());
+
+            if (machine.anyStateTransitions.Length > MaxTransitions)
+            {
+                result["anyStateTransitionCount"] = machine.anyStateTransitions.Length;
+            }
 
             result["entryTransitions"] = new JArray(
                 machine.entryTransitions.Select((t, i) => (object)AnimatorResolve.Transition(t, i, addressOf)).ToArray());

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AssetTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/AssetTools.cs
@@ -24,6 +24,9 @@ namespace UnityMCP.Editor.Tools
     /// </remarks>
     internal static class AssetTools
     {
+        /// <summary>Dependencies listed. A production scene points at thousands.</summary>
+        private const int MaxDependencies = 200;
+
         [McpTool(
             "asset_find",
             "Search the project for assets. Combine a type filter with a folder to keep the search " +
@@ -111,7 +114,7 @@ namespace UnityMCP.Editor.Tools
             "out unless include_dependencies is set.",
             Idempotency = McpIdempotency.Safe)]
         public static JObject Info(
-            [McpArg("path", "Project path of the asset, e.g. Assets/Art/Wood.mat.")]
+            [McpArg("path", "Project path of the asset, e.g. Assets/Art/Wood.mat.", Required = true)]
             string path = null,
             [McpArg("include_dependencies", "List the assets this one references.")]
             bool includeDependencies = false)
@@ -132,8 +135,18 @@ namespace UnityMCP.Editor.Tools
 
             if (includeDependencies)
             {
+                // Not recursive, but a scene's direct references are every material, texture,
+                // prefab and mesh its objects point at.
+                var dependencies = AssetDatabase.GetDependencies(path, false);
+
                 result["dependencies"] = new JArray(
-                    AssetDatabase.GetDependencies(path, false).Cast<object>().ToArray());
+                    dependencies.Take(MaxDependencies).Cast<object>().ToArray());
+                result["dependencyCount"] = dependencies.Length;
+
+                if (dependencies.Length > MaxDependencies)
+                {
+                    result["truncated"] = $"{dependencies.Length} dependencies";
+                }
             }
 
             return result;
@@ -147,7 +160,7 @@ namespace UnityMCP.Editor.Tools
             "not an error; the reply says created false.",
             Idempotency = McpIdempotency.Unsafe)]
         public static JObject CreateFolder(
-            [McpArg("path", "Folder to create, e.g. Assets/Art/Materials.")]
+            [McpArg("path", "Folder to create, e.g. Assets/Art/Materials.", Required = true)]
             string path = null)
         {
             if (string.IsNullOrWhiteSpace(path))
@@ -197,9 +210,9 @@ namespace UnityMCP.Editor.Tools
             "Move or rename an asset, keeping its GUID so references survive.",
             Idempotency = McpIdempotency.Unsafe)]
         public static JObject Move(
-            [McpArg("path", "Current project path of the asset.")]
+            [McpArg("path", "Current project path of the asset.", Required = true)]
             string path = null,
-            [McpArg("destination", "New path, including the file name and extension.")]
+            [McpArg("destination", "New path, including the file name and extension.", Required = true)]
             string destination = null)
         {
             Require(path);
@@ -244,7 +257,7 @@ namespace UnityMCP.Editor.Tools
             Idempotency = McpIdempotency.Unsafe)]
         public static JObject Delete(
             [McpArg("path", "Project path of the asset to remove. A folder is accepted and removes " +
-                            "the whole tree beneath it.")]
+                            "the whole tree beneath it.", Required = true)]
             string path = null)
         {
             Require(path);
@@ -265,7 +278,7 @@ namespace UnityMCP.Editor.Tools
             "Editor, and after changing importer settings.",
             Idempotency = McpIdempotency.Unsafe)]
         public static JObject Reimport(
-            [McpArg("path", "Asset or folder to reimport.")]
+            [McpArg("path", "Asset or folder to reimport.", Required = true)]
             string path = null,
             [McpArg("recursive", "For a folder, reimport everything inside it.")]
             bool recursive = true)

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/BuildTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/BuildTools.cs
@@ -71,7 +71,7 @@ namespace UnityMCP.Editor.Tools
             "stated rather than guessed.",
             Idempotency = McpIdempotency.Unsafe)]
         public static JObject BuildPlayer(
-            [McpArg("output_path", "Where to write the build, including the executable's file name.")]
+            [McpArg("output_path", "Where to write the build, including the executable's file name.", Required = true)]
             string outputPath = null,
             [McpArg("platform", "Build target, e.g. StandaloneWindows64, Android, iOS, WebGL. Defaults to the active one.")]
             string platform = null,

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ConsoleTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ConsoleTools.cs
@@ -41,7 +41,9 @@ namespace UnityMCP.Editor.Tools
             int offset = 0,
             [McpArg("type", "Severity filter: all, error, warning, or log.")]
             string type = "all",
-            [McpArg("fields", "Comma-separated field whitelist, to keep responses small.")]
+            [McpArg("fields", "Comma-separated field whitelist, to keep responses small. The " +
+                              "fields are 't' (severity), 'm' (message with its stack), 'f' " +
+                              "(file) and 'l' (line).")]
             string fields = null)
         {
             return LogReader.ReadLogs(ToolArgs.Of(

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorLogTool.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorLogTool.cs
@@ -66,7 +66,12 @@ namespace UnityMCP.Editor.Tools
             [McpArg("pattern", "Optional .NET regex; only matching lines are returned.")]
             string pattern = null,
             [McpArg("ignore_case", "Match the pattern case-insensitively.")]
-            bool ignoreCase = true)
+            bool ignoreCase = true,
+            [McpArg("since", "A 'position' from an earlier reply. Returns only what the log has " +
+                             "gained since then, which is what a check after an action wants. " +
+                             "A position past the end means the log was replaced, and the tail " +
+                             "is returned instead with 'restarted' set.")]
+            long since = 0)
         {
             var path = logPath;
 
@@ -97,13 +102,14 @@ namespace UnityMCP.Editor.Tools
             }
 
             var requested = Math.Max(1, Math.Min(lines, MaxLines));
-            var text = ReadTail(path, out var totalBytes, out var readBytes);
+            var text = ReadFrom(path, since, out var totalBytes, out var readBytes, out var restarted);
 
             var all = text.Split('\n');
             var matched = new List<string>();
 
             // The first element is usually a partial line left over from the byte-offset read.
-            var start = readBytes < totalBytes ? 1 : 0;
+            // Resuming from a position given by an earlier reply lands on a line boundary instead.
+            var start = readBytes < totalBytes && since <= 0 ? 1 : 0;
 
             for (var i = start; i < all.Length; i++)
             {
@@ -140,33 +146,60 @@ namespace UnityMCP.Editor.Tools
 
             kept.Reverse();
 
+            // Folding first: a run of alike lines is what the pipeline writes, and it is most of
+            // a tail. Trimming afterwards works on the frames that are left.
+            var folded = LogNoise.TrimStacks(LogNoise.FoldRepeats(kept, out var hidden));
+
             return new LogTailResult
             {
                 Path = path,
                 FileBytes = totalBytes,
                 ScannedBytes = readBytes,
                 Matched = matched.Count,
-                Returned = kept.Count,
+                Returned = folded.Count,
                 Truncated = truncated,
-                Lines = kept,
+                Restarted = restarted,
+                FoldedAway = hidden,
+                Position = totalBytes,
+                Lines = folded,
             };
         }
 
         /// <summary>
-        /// Reads the last <see cref="MaxTailBytes"/> of the file.
+        /// Reads from <paramref name="since"/>, or the last <see cref="MaxTailBytes"/> when that is
+        /// zero or no longer inside the file.
         /// </summary>
         /// <remarks>
         /// <c>FileShare.ReadWrite</c> is required: Unity holds the log open for writing, and
         /// anything stricter fails with a sharing violation.
         /// </remarks>
-        private static string ReadTail(string path, out long totalBytes, out int readBytes)
+        private static string ReadFrom(
+            string path, long since, out long totalBytes, out int readBytes, out bool restarted)
         {
             using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
             totalBytes = stream.Length;
-            readBytes = (int)Math.Min(totalBytes, MaxTailBytes);
 
-            stream.Seek(-readBytes, SeekOrigin.End);
+            // A position past the end means the Editor started a new log, so there is nothing to
+            // resume from and the tail is the honest answer.
+            restarted = since > totalBytes;
+
+            if (since > 0 && !restarted)
+            {
+                readBytes = (int)Math.Min(totalBytes - since, MaxTailBytes);
+                stream.Seek(since, SeekOrigin.Begin);
+            }
+            else
+            {
+                readBytes = (int)Math.Min(totalBytes, MaxTailBytes);
+                stream.Seek(-readBytes, SeekOrigin.End);
+            }
+
+            if (readBytes == 0)
+            {
+                return string.Empty;
+            }
+
 
             var buffer = new byte[readBytes];
             var offset = 0;
@@ -200,6 +233,15 @@ namespace UnityMCP.Editor.Tools
 
             /// <summary>True when lines were dropped, so the caller knows not to treat this as complete.</summary>
             public bool Truncated { get; set; }
+
+            /// <summary>True when 'since' pointed past the end, so the log had been replaced.</summary>
+            public bool Restarted { get; set; }
+
+            /// <summary>Lines left out because an identical-shaped one was already reported.</summary>
+            public int FoldedAway { get; set; }
+
+            /// <summary>Pass back as 'since' to read only what arrives after this call.</summary>
+            public long Position { get; set; }
 
             public List<string> Lines { get; set; }
         }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/EditorTools.cs
@@ -24,7 +24,9 @@ namespace UnityMCP.Editor.Tools
             "everywhere. A screen-read view returns whatever is drawn in that rectangle, so the call " +
             "is refused when another application is in front of the Editor. It also focuses the " +
             "window first, which raises a docked tab over whatever the person at the Editor was " +
-            "looking at.",
+            "looking at. An MCP client receives the picture as an image; the CLI writes it to " +
+            "a file and prints the path, because the same picture costs about ninety times as " +
+            "much read out of a terminal as base64 than it does as an image.",
             Idempotency = McpIdempotency.Safe)]
         public static JObject CaptureScreenshot(
             [McpArg("view", "What to capture. 'game' and 'scene' render through the camera. " +

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GameObjectTools.cs
@@ -260,7 +260,7 @@ namespace UnityMCP.Editor.Tools
             string objectPath = null,
             [McpArg("instance_id", "Instance id, instead of a path.")]
             long? instanceId = null,
-            [McpArg("component_type", "Type name of the component to add.")]
+            [McpArg("component_type", "Type name of the component to add.", Required = true)]
             string componentType = null)
         {
             var go = ObjectResolve.Object(objectPath, instanceId);
@@ -291,7 +291,7 @@ namespace UnityMCP.Editor.Tools
             [McpArg("instance_id", "Instance id, instead of a path.")]
             long? instanceId = null,
             [McpArg("component_type", "Type name of the component to remove. Short or fully " +
-                                      "qualified, and a base type matches a derived component.")]
+                                      "qualified, and a base type matches a derived component.", Required = true)]
             string componentType = null,
             [McpArg("index", "Which one, when the object carries several of the same type.")]
             int index = 0)

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GpuTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/GpuTools.cs
@@ -23,6 +23,13 @@ namespace UnityMCP.Editor.Tools
     /// </remarks>
     internal static class GpuTools
     {
+        /// <summary>
+        /// Ceilings on what the reply carries. Samples and buckets were bounded only by the data,
+        /// so a large ask against a 4096-square texture answered with millions of numbers.
+        /// </summary>
+        private const int MaxSamples = 256;
+        private const int MaxBuckets = 256;
+
         [McpTool(
             "gpu_readback",
             "Read a GPU buffer or texture back and report its statistics: range, mean, how many " +
@@ -256,12 +263,23 @@ namespace UnityMCP.Editor.Tools
 
             if (samples > 0)
             {
-                meta["samples"] = new JArray(values.Skip(start).Take(Math.Min(samples, length))
+                // Capped: these are for recognising the data, not for transferring it, and each
+                // value serialises to as much as nineteen characters.
+                var wanted = Math.Min(Math.Min(samples, MaxSamples), length);
+
+                meta["samples"] = new JArray(values.Skip(start).Take(wanted)
                     .Select(v => (object)v).ToArray());
+
+                if (samples > wanted)
+                {
+                    meta["samplesCapped"] = MaxSamples;
+                }
             }
 
             if (buckets > 0 && max > min)
             {
+                buckets = Math.Min(buckets, MaxBuckets);
+
                 var counts = new int[buckets];
 
                 for (var i = start; i < start + length; i++)

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/Input/InputTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/Input/InputTools.cs
@@ -50,7 +50,7 @@ namespace UnityMCP.Editor.Tools
             string action = "move",
             [McpArg("button", "Mouse button: 0 left, 1 right, 2 middle.")]
             int button = 0,
-            [McpArg("from", "[x, y] where the gesture starts. Required.")]
+            [McpArg("from", "[x, y] where the gesture starts.", Required = true)]
             double[] from = null,
             [McpArg("to", "[x, y] where a drag ends. Ignored by other actions.")]
             double[] to = null,

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/InspectorTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/InspectorTools.cs
@@ -63,7 +63,11 @@ namespace UnityMCP.Editor.Tools
             int? limit = null,
             [McpArg("fields", "Comma-separated field whitelist, to keep responses small.")]
             string fields = null,
-            [McpArg("detail", "Level of per-property detail: standard or full.")]
+            [McpArg("detail", "How much to say about each component: summary is the type and " +
+                              "index alone, standard adds whether it is enabled, full adds its " +
+                              "serialized properties. Applies only when 'component_type' is " +
+                              "omitted; naming a component returns that component's properties, " +
+                              "which this does not change.")]
             string detail = "standard")
         {
             return InspectorAccess.Access(ToolArgs.Of(

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/PrefabTools.cs
@@ -28,7 +28,7 @@ namespace UnityMCP.Editor.Tools
             string objectPath = null,
             [McpArg("instance_id", "Instance id of that scene object, instead of object_path.")]
             long? instanceId = null,
-            [McpArg("path", "Project path of the prefab asset to write, e.g. Assets/Prefabs/Enemy.prefab.")]
+            [McpArg("path", "Project path of the prefab asset to write, e.g. Assets/Prefabs/Enemy.prefab.", Required = true)]
             string path = null,
             [McpArg("connect", "Leave the scene object linked to the new prefab.")]
             bool connect = true,
@@ -77,7 +77,7 @@ namespace UnityMCP.Editor.Tools
             Idempotency = McpIdempotency.Unsafe,
             UndoGroup = "MCP Instantiate Prefab")]
         public static JObject Instantiate(
-            [McpArg("path", "Project path of the prefab asset.")]
+            [McpArg("path", "Project path of the prefab asset.", Required = true)]
             string path = null,
             [McpArg("parent_path", "Hierarchy path of the parent; omit for the scene root.")]
             string parentPath = null,

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ReflectTools.cs
@@ -52,7 +52,7 @@ namespace UnityMCP.Editor.Tools
             "fresh instance. Read sharedMaterial and sharedMesh instead when you only want to look.",
             Idempotency = McpIdempotency.Safe)]
         public static JObject Read(
-            [McpArg("path", "Type name or instance root, then members: 'Namespace.Type/field/other[3]', '@selection/transform/position'.")]
+            [McpArg("path", "Type name or instance root, then members: 'Namespace.Type/field/other[3]', '@selection/transform/position'.", Required = true)]
             string path = null,
             [McpArg("depth", "How deep to serialise nested objects.")]
             int depth = 2,
@@ -95,7 +95,7 @@ namespace UnityMCP.Editor.Tools
             "Find loaded types by name, when the full name for reflect_read is not known.",
             Idempotency = McpIdempotency.Safe)]
         public static JObject FindType(
-            [McpArg("name", "Name or fragment to match, case-insensitive.")]
+            [McpArg("name", "Name or fragment to match, case-insensitive.", Required = true)]
             string name = null,
             [McpArg("limit", "Maximum matches to return.")]
             int limit = 30)
@@ -538,15 +538,51 @@ namespace UnityMCP.Editor.Tools
 
         // ── serialisation ──
 
+        /// <summary>
+        /// Ceilings the caller cannot raise. depth bounds how deep the walk goes and max_items how
+        /// wide each level is, but they multiply, so a value either one allows can still be the
+        /// product of the two. The node budget is what actually bounds the reply.
+        /// </summary>
+        private const int MaxDepth = 4;
+        private const int MaxItemsCeiling = 200;
+        private const int MaxNodes = 2000;
+
+        /// <summary>
+        /// A string is returned ahead of every depth and collection check, so nothing else can
+        /// shorten a serialised blob or a shader's source held in a field.
+        /// </summary>
+        private const int MaxStringLength = 4000;
+
+        /// <summary>Fields read from one object. Their order is unspecified, so which ones survive is too.</summary>
+        private const int MaxFields = 60;
+
         internal static JToken Serialize(object value, int depth, int maxItems)
         {
+            var budget = MaxNodes;
+
+            return Serialize(
+                value,
+                Math.Min(Math.Max(depth, 0), MaxDepth),
+                Math.Min(Math.Max(maxItems, 0), MaxItemsCeiling),
+                ref budget);
+        }
+
+        private static JToken Serialize(object value, int depth, int maxItems, ref int budget)
+        {
+            if (budget-- <= 0)
+            {
+                return new JObject { ["truncated"] = "budget" };
+            }
+
             switch (value)
             {
                 case null:
                     return JValue.CreateNull();
 
                 case string s:
-                    return s;
+                    return s.Length <= MaxStringLength
+                        ? s
+                        : s.Substring(0, MaxStringLength) + $"… ({s.Length} characters)";
 
                 case bool b:
                     return b;
@@ -618,7 +654,7 @@ namespace UnityMCP.Editor.Tools
                         break;
                     }
 
-                    o[entry.Key?.ToString() ?? "null"] = Serialize(entry.Value, depth - 1, maxItems);
+                    o[entry.Key?.ToString() ?? "null"] = Serialize(entry.Value, depth - 1, maxItems, ref budget);
                 }
 
                 return o;
@@ -638,7 +674,7 @@ namespace UnityMCP.Editor.Tools
                         break;
                     }
 
-                    a.Add(Serialize(item, depth - 1, maxItems));
+                    a.Add(Serialize(item, depth - 1, maxItems, ref budget));
                 }
 
                 if (!more)
@@ -650,12 +686,18 @@ namespace UnityMCP.Editor.Tools
             }
 
             var result = new JObject { ["__type"] = type.FullName };
+            var fields = type.GetFields(AllInstance);
 
-            foreach (var field in type.GetFields(AllInstance).Take(60))
+            if (fields.Length > MaxFields)
+            {
+                result["__truncated"] = $"{fields.Length} fields";
+            }
+
+            foreach (var field in fields.Take(MaxFields))
             {
                 try
                 {
-                    result[field.Name] = Serialize(field.GetValue(value), depth - 1, maxItems);
+                    result[field.Name] = Serialize(field.GetValue(value), depth - 1, maxItems, ref budget);
                 }
                 catch (Exception e)
                 {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/RenderTools.cs
@@ -19,6 +19,12 @@ namespace UnityMCP.Editor.Tools
     /// </summary>
     internal static class RenderTools
     {
+        /// <summary>
+        /// Cameras reported. Each runs to about a kilobyte with its matrices, and a cinematic
+        /// scene keeps one per shot.
+        /// </summary>
+        private const int MaxCameras = 50;
+
         [McpTool(
             "render_compare",
             "Compare two captured images and report how they differ, in numbers. Use this instead of " +
@@ -29,9 +35,9 @@ namespace UnityMCP.Editor.Tools
             "images have to be the same size.",
             Idempotency = McpIdempotency.Safe)]
         public static JObject Compare(
-            [McpArg("before", "Path to the first PNG, from capture_screenshot's save_path.")]
+            [McpArg("before", "Path to the first PNG, from capture_screenshot's save_path.", Required = true)]
             string before = null,
-            [McpArg("after", "Path to the second PNG.")]
+            [McpArg("after", "Path to the second PNG.", Required = true)]
             string after = null,
             [McpArg("threshold", "Largest per-channel difference, 0-255, at or below which a pixel " +
                                  "counts as unchanged. Only red, green and blue are compared; alpha " +
@@ -217,13 +223,16 @@ namespace UnityMCP.Editor.Tools
             "to tell which are drawing.",
             Idempotency = McpIdempotency.Safe)]
         public static JObject CameraInfo(
-            [McpArg("name", "Only report the camera with this name.")]
+            [McpArg("name", "Only report cameras whose name contains this text, ignoring case. " +
+                            "Without it every camera in the open scenes is reported, inactive " +
+                            "ones included.")]
             string name = null,
             [McpArg("include_matrices", "Include the view and projection matrices, row-major.")]
             bool includeMatrices = true)
         {
             var cameras = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsInactive.Include, FindObjectsSortMode.None)
-                .Where(c => string.IsNullOrWhiteSpace(name) || c.name == name)
+                .Where(c => string.IsNullOrWhiteSpace(name)
+                            || c.name.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0)
                 .OrderByDescending(c => c.isActiveAndEnabled)
                 .ThenBy(c => c.depth)
                 .ToArray();
@@ -237,7 +246,9 @@ namespace UnityMCP.Editor.Tools
                         : $"No camera named '{name}'.");
             }
 
-            var list = new JArray(cameras.Select(c =>
+            var shown = cameras.Take(MaxCameras).ToArray();
+
+            var list = new JArray(shown.Select(c =>
             {
                 var entry = new JObject
                 {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/SceneTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/SceneTools.cs
@@ -155,7 +155,7 @@ namespace UnityMCP.Editor.Tools
             "rather than being discarded, unless the scene is being added additively.",
             Idempotency = McpIdempotency.Unsafe)]
         public static JObject Open(
-            [McpArg("path", "Project path of the scene, e.g. Assets/Scenes/Main.unity.")]
+            [McpArg("path", "Project path of the scene, e.g. Assets/Scenes/Main.unity.", Required = true)]
             string path = null,
             [McpArg("additive", "Add to the open scenes instead of replacing them.")]
             bool additive = false)

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ShaderTools.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tools/ShaderTools.cs
@@ -80,6 +80,8 @@ namespace UnityMCP.Editor.Tools
 
                     if (messages.Count >= Math.Max(limit, 0))
                     {
+                        // Counting continues so `truncated` stays honest; only the message list
+                        // stops growing.
                         continue;
                     }
 

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "Drive the Unity Editor from an AI agent or the terminal. The Editor serves MCP itself, so there is no second process to run, and the isuzu-unity-cli command needs no Node or .NET runtime.",

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author": "Shiranui_Isuzu",
   "unity": "2022.3",
   "description": "Drive the Unity Editor from an AI agent or the terminal. The Editor serves MCP itself, so there is no second process to run, and the isuzu-unity-cli command needs no Node or .NET runtime.",

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "2c702a0db5a13bad38f150270c3aa6d999370d29c96df9edd0e2ab636ea1186d",
-    "total":  525,
-    "passed":  524,
+    "sourceHash":  "fd972b18e8a89542acae918cf5ed1ca86f3a534ccb6cdb1d09b833c15ecdd152",
+    "total":  552,
+    "passed":  551,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-09T05:58:44.3729062Z"
+    "ranAt":  "2026-09-09T09:38:26.7177183Z"
 }

--- a/scripts/editmode-attestation.json
+++ b/scripts/editmode-attestation.json
@@ -1,9 +1,9 @@
 {
-    "sourceHash":  "6e917157f407cfbd09ad23c1f6d38c6ba224221f8e8da291b4a4535101a5f1f2",
+    "sourceHash":  "2c702a0db5a13bad38f150270c3aa6d999370d29c96df9edd0e2ab636ea1186d",
     "total":  525,
     "passed":  524,
     "failed":  0,
     "skipped":  1,
     "unityVersion":  "6000.0.35f1",
-    "ranAt":  "2026-09-08T16:33:48.7470231Z"
+    "ranAt":  "2026-09-09T05:58:44.3729062Z"
 }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.shiranui-isuzu/unity-mcp",
   "title": "Unity MCP",
   "description": "Unity Editor automation for AI agents: scenes, prefabs, assets, shaders, Timeline, tests, builds.",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "repository": {
     "url": "https://github.com/isuzu-shiranui/UnityMCP",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "nuget",
       "identifier": "IsuzuUnityCli",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.shiranui-isuzu/unity-mcp",
   "title": "Unity MCP",
   "description": "Unity Editor automation for AI agents: scenes, prefabs, assets, shaders, Timeline, tests, builds.",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "repository": {
     "url": "https://github.com/isuzu-shiranui/UnityMCP",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "nuget",
       "identifier": "IsuzuUnityCli",
-      "version": "4.1.2",
+      "version": "4.2.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
An agent reads a tool's schema to decide what to send, and reads the reply into a conversation
that carries it on every later turn. Both ends were leaking, so this release is about arguments
the caller sets and the handler then ignores, and replies whose size follows the project rather
than the request.

All figures below come from one Editor, with the same input on both sides.

| | before | after | |
|---|---:|---:|---:|
| `editor_log_tail`, 2000-line cap | 194,583 tok | **8,902** | −95% |
| `editor_log_tail`, default | 20,152 tok | **2,542** | −87% |
| `editor_log_tail`, read again with `since` | 20,152 tok | **105** | −99% |
| `project_packages` with `limit: 2` | 29,214 tok | **522** | −98% |
| `project_assemblies`, default | 24,350 tok | **12,235** | −50% |
| `capture_screenshot --raw` (CLI) | 84,870 B | **337 B** | |
| `input_replay` with `then_capture` (CLI) | 85,143 B | **606 B** | |
| `capture_screenshot` (MCP, whole reply) | 169,806 ch | **85,021 ch** | −50% |

One figure goes up. `console_read_logs` grows from 31,348 to 39,148 bytes because cutting each
message at 500 characters spent the budget on the test runner rather than the test: none of fifty
entries kept a frame naming a file and a line, several severed mid-path. It now keeps the frames
that name source and counts the rest — fifty of fifty.

## Breaking

- `project_assemblies` no longer returns `fullName`. It repeated the `name` and `version` beside
  it, then the same culture and token boilerplate on nearly every row.
- A `fields` list matching nothing on the entries returned is refused instead of answered with
  empty objects. Three tools took that parameter and did three different things with a name that
  matched nothing, none of them saying so. The refusal is judged over the page, so a field only
  some rows carry still counts.
- Thirty tools declare the thirty-six arguments their handlers already demanded, so a client that
  validates against the schema refuses those calls up front rather than sending them to be
  rejected. Arguments wanted only in some situations stay optional.

## Fixed

- A picture is found wherever a tool puts it, rather than in two hardcoded places. `input_replay`
  with `then_capture` shipped 80,216 tokens of base64 as a text block over MCP — the route that
  exists to avoid exactly that — and `--raw` returned before the CLI moved the picture to disk.
- An MCP reply carried the base64 twice, once as an image block and once in `structuredContent`.
- `project_packages` with `include_registry` returned the whole registry however small a `limit`
  was asked for, because the registry half was built outside the paging.
- `inspect_write` with no `component_type` listed the object's components and wrote nothing,
  reporting a result rather than a failure.
- `inspect_list` ignored `offset` and `limit` when a component was named.
- `console_read_logs` compared an unknown `type` against each severity in turn, matched none, and
  returned every entry.
- `capture_screenshot` scaled an explicit `width` or `height` down to `max_size`, which their own
  descriptions say they override.
- `timeline_inspect` discarded `include_clips` when it followed a Control track into a child
  timeline.
- A refusal raised inside a handler was folded into that tool's generic failure, so a wrong
  argument read as the Editor being unreadable and a caller retried instead of correcting it.

## Changed

- `editor_log_tail` folds lines whose shape repeats and takes a `since` position; a line reporting
  a problem is never folded.
- Ceilings where a reply's size followed the project: `reflect_read` walks a node budget (depth
  and item count multiply, so neither bounds a reply alone), `animator_inspect` bounds both its
  axes, `asset_info` its dependencies, `render_camera_info` its cameras, `gpu_readback` its
  samples. Each says what it left out and how many there were.
- `render_camera_info` matches `name` as a case-insensitive substring; exact matching selected one
  camera or none.
- `maxResultSizeChars` is documented as the hint it is. Nothing in the package measures a response
  or cuts one, so a tool can and does answer above its own stated number.

## Verification

EditMode 552 (551 passed, 1 skipped, 0 failed) on 6000.0.35f1, attestation `fd972b18`. CLI 229
passed. The figures above come from a live 6000.5.10f1 Editor.
