### PR TITLE
feat: add Vietnamese localization and setup guide

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -7,7 +7,7 @@
 ![.NET](https://img.shields.io/badge/.NET-10-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)
 
-[日本語版](./README.md)
+[日本語版](./README.md) | [Tiếng Việt](./README.vi.md)
 
 This framework opens the Unity Editor to AI agents. Running a command by hand and calling it from a script go through the same path.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![.NET](https://img.shields.io/badge/.NET-10-purple.svg)
 ![GitHub Stars](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)
 
-[English Version](./README.en.md)
+[English Version](./README.en.md) | [Tiếng Việt](./README.vi.md)
 
 Unity Editor を AI エージェントに開放するフレームワークです。人が手で実行しても、スクリプトから呼んでも、同じ経路を通ります。
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,0 +1,136 @@
+# Framework tích hợp Unity MCP
+
+<!-- mcp-name: dev.shiranui-isuzu/unity-mcp -->
+
+[![Giấy phép: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+![Unity](https://img.shields.io/badge/Unity-2022.3%E2%80%93Unity6-black.svg)
+![.NET](https://img.shields.io/badge/.NET-10-purple.svg)
+![Sao trên GitHub](https://img.shields.io/github/stars/isuzu-shiranui/UnityMCP?style=social)
+
+[日本語](./README.md) | [English](./README.en.md)
+
+Framework này cho phép tác nhân AI thao tác với Unity Editor. Lệnh chạy thủ công và lệnh gọi từ script đều đi qua cùng một đường xử lý.
+
+- Ứng dụng khách MCP kết nối trực tiếp đến điểm cuối Streamable HTTP do chính Editor cung cấp tại `http://127.0.0.1:<port>/mcp`. Không có tiến trình máy chủ MCP riêng. Dự án đã kiểm tra kết nối với Claude Code, Cursor, Codex, Gemini CLI, VS Code và Claude Desktop.
+- Công cụ dòng lệnh `isuzu-unity-cli` gọi cùng các công cụ đó. Các tệp thực thi được phát hành là mã máy, không cần Node hay môi trường chạy .NET.
+- Mỗi công cụ là một phương thức C# tĩnh có thuộc tính `[McpTool]`.
+
+Nếu đây là lần đầu sử dụng, hãy bắt đầu với [Bắt đầu sử dụng Unity MCP](https://unity-mcp.shiranui-isuzu.dev/vi/), hướng dẫn cài đặt có hình minh họa.
+
+## Yêu cầu
+
+- Unity Editor 2022.3 trở lên. Bộ kiểm thử EditMode của dự án được chạy trên Unity 6000.0.35f1
+- Git 2.14.0 trở lên, có trong `PATH`. Package Manager của Unity dùng Git để tải gói từ URL Git ([hướng dẫn Unity, tiếng Anh](https://docs.unity3d.com/Manual/upm-git.html)). Cài qua kho VPM bên dưới thì không cần Git
+- `com.unity.nuget.newtonsoft-json` 3.2.1. Gói này được tự động cài đặt theo quan hệ phụ thuộc
+
+## Cài đặt
+
+Trong Package Manager của Unity, chọn **Add package from git URL** rồi nhập:
+
+```
+https://github.com/isuzu-shiranui/UnityMCP.git?path=jp.shiranui-isuzu.unity-mcp
+```
+
+Với VRChat Creator Companion (VCC) hoặc ALCOM, bạn có thể thêm kho VPM `https://unity-mcp.shiranui-isuzu.dev/vpm.json`. Cả hai tải gói dưới dạng zip nên không cần Git. Liên kết thêm kho bằng một lần nhấp và vị trí nút thêm kho trong từng ứng dụng nằm ở phần [VCC và ALCOM](https://unity-mcp.shiranui-isuzu.dev/vi/#vpm-title) của hướng dẫn bắt đầu.
+
+Để chuyển giao diện Unity MCP sang tiếng Việt, mở Preferences > Unity MCP > Settings và chọn **Tiếng Việt** ở mục Language. Tùy chọn này áp dụng cho trang Preferences của Unity MCP; mô tả công cụ và đầu ra CLI vẫn dùng tiếng Anh.
+
+Cài CLI:
+
+```bash
+# Windows
+irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 | iex
+
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh
+```
+
+Bạn cũng có thể tải tệp thực thi từ GitHub Releases và đối chiếu mã băm với `SHA256SUMS`. Nếu đã cài .NET SDK, bạn có thể dùng `dotnet tool install -g IsuzuUnityCli`.
+
+Sau đó cài skill cho tác nhân AI và đăng ký ứng dụng khách MCP:
+
+```bash
+isuzu-unity-cli setup                              # skill cho Claude Code và Codex
+isuzu-unity-cli setup --mcp --agent claude-code    # đăng ký ứng dụng khách MCP
+```
+
+`--agent` chấp nhận `claude-code`, `claude-desktop`, `codex`, `cursor`, `gemini` hoặc `vscode`. Claude Code lưu cấu hình máy chủ theo đường dẫn dự án Unity, vì vậy hãy khởi chạy Claude Code trong thư mục dự án Unity. Bạn cũng có thể đăng ký ứng dụng khách từ Preferences > Unity MCP trong Editor.
+
+Cấu hình từng ứng dụng khách, gói tiện ích mở rộng cho Claude Desktop và cầu nối stdio được mô tả trong [Kết nối ứng dụng khách MCP (tiếng Anh)](docs/en/mcp-clients.md).
+
+## Các lệnh đầu tiên
+
+Máy chủ khởi chạy khi Editor mở dự án và tạo tệp mô tả kết nối (descriptor). CLI đọc tệp này nên bạn không cần nhập cổng hay token.
+
+```bash
+isuzu-unity-cli projects                  # các Editor đang chạy
+isuzu-unity-cli tools                     # công cụ do Editor này cung cấp
+isuzu-unity-cli call play_mode_status     # gọi một công cụ
+isuzu-unity-cli verify                    # biên dịch lại, thu thập lỗi, đọc lỗi Console
+```
+
+`verify` gộp việc biên dịch lại và thu thập lỗi sau khi sửa script vào một lần gọi. Thêm `--test` để chạy cả kiểm thử.
+
+Khi mở nhiều Editor, chọn dự án bằng `--project <name>`. Nếu chạy lệnh trong thư mục dự án, CLI sẽ tự chọn. Tất cả lệnh được mô tả trong [tài liệu CLI (tiếng Anh)](docs/en/cli.md).
+
+## Công cụ
+
+Các công cụ hỗ trợ chẩn đoán (Console, `Editor.log`, trạng thái biên dịch, kiểm thử, cấu trúc phân cấp scene, đọc asset); tạo và chỉnh sửa GameObject, component, asset, scene, prefab và Animator Controller; kết xuất; Timeline và Recorder; build; chạy đoạn mã C#; và mô phỏng thao tác trong Editor. Mỗi lần gọi công cụ tạo hoặc chỉnh sửa được gộp thành một bước Undo.
+
+Công cụ Timeline chỉ xuất hiện khi có `com.unity.timeline`; công cụ Recorder cần cả `com.unity.recorder` và `com.unity.timeline`; `test_run` và `test_results` cần `com.unity.test-framework`.
+
+Danh sách đầy đủ cùng các lưu ý trước khi chỉnh sửa nằm trong [tài liệu công cụ (tiếng Anh)](docs/en/tools.md). Thêm `?group=diagnostics,authoring` vào URL MCP để `tools/list` chỉ trả về các nhóm đó.
+
+## Thêm công cụ
+
+Viết một phương thức trong Editor.
+
+```csharp
+using System.Linq;
+using UnityMCP.Editor.Core;
+using UnityMCP.Editor.Core.Attributes;
+
+internal static class MyTools
+{
+    [McpTool(
+        "asset_find_by_type",
+        "Find project assets of a given type. Prefer a narrow type and a small limit.",
+        Idempotency = McpIdempotency.Safe)]
+    public static string[] FindByType(
+        [McpArg("type", "Unity type name, e.g. Material.")] string type,
+        [McpArg("limit", "Maximum paths to return.")] int limit = 50)
+    {
+        return UnityEditor.AssetDatabase.FindAssets($"t:{type}")
+            .Take(limit)
+            .Select(UnityEditor.AssetDatabase.GUIDToAssetPath)
+            .ToArray();
+    }
+}
+```
+
+Như vậy, công cụ đã có thể được gọi từ cả ứng dụng khách MCP lẫn CLI. JSON Schema được tạo từ chữ ký phương thức. Các thuộc tính mà `[McpTool]` chấp nhận được liệt kê trong [Kiến trúc (tiếng Anh)](docs/en/architecture.md).
+
+Bạn cũng có thể thêm công cụ bằng tệp JSON mà không viết C#. Xem [Công cụ định nghĩa bằng JSON (tiếng Anh)](docs/en/defined-tools.md).
+
+## Tài liệu
+
+Các tài liệu kỹ thuật dưới đây hiện dùng tiếng Anh; CHANGELOG dùng tiếng Nhật.
+
+- [Danh sách công cụ](docs/en/tools.md): toàn bộ công cụ và các lưu ý trước khi chỉnh sửa
+- [Kết nối ứng dụng khách MCP](docs/en/mcp-clients.md): cấu hình từng ứng dụng khách, cầu nối Claude Desktop, thông tin giao thức
+- [Tài liệu CLI](docs/en/cli.md): toàn bộ lệnh, chọn dự án, mã thoát, những tệp được lưu trên máy
+- [Công cụ định nghĩa bằng JSON](docs/en/defined-tools.md): công cụ `probe`, `script` và `sequence` từ tệp JSON
+- [Mô phỏng, ghi và phát lại thao tác trong Editor](docs/en/input-tools.md): `input_pointer`, `input_key`, `input_record`, `input_replay`
+- [Kiến trúc](docs/en/architecture.md): sơ đồ, các lớp phía Editor, cài đặt, kiểm thử
+- [Khắc phục sự cố](docs/en/troubleshooting.md)
+- [Bảo mật](docs/en/security.md)
+- [Chuyển từ v3](docs/en/migration-v3.md)
+- [CHANGELOG](jp.shiranui-isuzu.unity-mcp/CHANGELOG.md)
+
+## Bảo mật
+
+Máy chủ chỉ lắng nghe trên `127.0.0.1`, và mọi yêu cầu trừ `OPTIONS` đều cần token Bearer. Hãy bảo vệ tệp mô tả kết nối và tệp token như thông tin xác thực: bất kỳ ai hoặc chương trình nào đọc được chúng đều có thể chạy mã trong Editor. Không có mã của gói trong bản build ứng dụng, kể cả Development Build. Chi tiết nằm trong [Bảo mật (tiếng Anh)](docs/en/security.md).
+
+## Giấy phép
+
+MIT

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Settings/McpEditorText.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Settings/McpEditorText.cs
@@ -11,6 +11,7 @@ namespace UnityMCP.Editor.Settings
         Auto = 0,
         English = 1,
         Japanese = 2,
+        Vietnamese = 3,
     }
 
     /// <summary>
@@ -111,6 +112,83 @@ namespace UnityMCP.Editor.Settings
             ["Troubleshooting"] = "トラブルシューティング",
         };
 
+        private static readonly Dictionary<string, string> Vietnamese = new Dictionary<string, string>
+        {
+            // Setup
+            ["Setup"] = "Thiết lập",
+            ["Listening on port {0}"] = "Đang lắng nghe trên cổng {0}",
+            ["Server stopped"] = "Máy chủ đã dừng",
+            ["Server not initialized"] = "Máy chủ chưa được khởi tạo",
+            ["Start"] = "Khởi chạy",
+            ["Stop"] = "Dừng",
+            ["Initialize"] = "Khởi tạo",
+            ["isuzu-unity-cli found"] = "Đã tìm thấy isuzu-unity-cli",
+            ["isuzu-unity-cli not found on PATH"] = "Không tìm thấy isuzu-unity-cli trong PATH",
+            ["Install"] = "Cài đặt",
+            ["Register"] = "Đăng ký",
+            ["Registered in {0} client configuration(s)"] = "Đã đăng ký trong {0} cấu hình ứng dụng khách",
+            ["No MCP client points at this Editor"] = "Chưa có ứng dụng khách MCP nào trỏ tới Editor này",
+            ["setup --mcp finished without saying anything."] = "setup --mcp đã kết thúc mà không xuất thông báo nào.",
+            ["Could not run {0}: {1}"] = "Không thể chạy {0}: {1}",
+            ["Refresh"] = "Kiểm tra lại",
+            ["Copy command"] = "Sao chép lệnh",
+            ["Register an MCP client with the configuration below, or run isuzu-unity-cli setup --mcp."] =
+                "Đăng ký ứng dụng khách MCP bằng cấu hình bên dưới, hoặc chạy isuzu-unity-cli setup --mcp.",
+            ["Command-line agents need the CLI. MCP clients reach the endpoint below without it."] =
+                "Tác nhân AI dùng dòng lệnh cần có CLI. Ứng dụng khách MCP kết nối trực tiếp đến điểm cuối bên dưới mà không cần CLI.",
+            ["Port {0} was busy, so this Editor is on {1}. Clients configured for the usual URL cannot reach it. Close whatever holds the port, or pin an HTTP Port in Settings and register the clients again."] =
+                "Cổng {0} đang được sử dụng, nên Editor này dùng cổng {1}. Ứng dụng khách được cấu hình với URL thông thường sẽ không kết nối được. Hãy đóng ứng dụng đang chiếm cổng, hoặc đặt Cổng HTTP cố định trong Cài đặt rồi đăng ký lại các ứng dụng khách.",
+
+            // Connection
+            ["Connection"] = "Kết nối",
+            ["MCP URL"] = "URL MCP",
+            ["Bearer token"] = "Token Bearer",
+            ["Configuration for"] = "Cấu hình cho",
+            ["Copy"] = "Sao chép",
+            ["Regenerate"] = "Tạo lại",
+            ["Show"] = "Hiện",
+            ["Hide"] = "Ẩn",
+            ["Start the server to see the connection details."] = "Khởi chạy máy chủ để xem thông tin kết nối.",
+            ["The descriptor and token files under {0} are credentials. Anything that can read them can run code in this Editor."] =
+                "Các tệp mô tả kết nối và tệp token trong {0} chứa thông tin xác thực. Bất kỳ ai hoặc chương trình nào đọc được chúng đều có thể chạy mã trong Editor này.",
+            ["Regenerate token"] = "Tạo lại token",
+            ["Every MCP client registered with the current token stops working until it is registered again with isuzu-unity-cli doctor --fix. Continue?"] =
+                "Mọi ứng dụng khách MCP đã đăng ký bằng token hiện tại sẽ ngừng hoạt động cho đến khi được đăng ký lại bằng isuzu-unity-cli doctor --fix. Tiếp tục?",
+            ["Cancel"] = "Hủy",
+
+            // Settings
+            ["Settings"] = "Cài đặt",
+            ["HTTP Port"] = "Cổng HTTP",
+            ["0 derives a stable port from the project path, which is what MCP client configuration relies on. Set a positive port only to resolve a collision; clients then have to be registered again."] =
+                "Giá trị 0 xác định cổng cố định từ đường dẫn dự án; cấu hình ứng dụng khách MCP dựa vào cổng này. Chỉ đặt số cổng dương để giải quyết xung đột; khi đó cần đăng ký lại các ứng dụng khách.",
+            ["A port must be 0, or between 1024 and 65535. The server cannot bind {0}."] =
+                "Cổng phải là 0 hoặc nằm trong khoảng 1024 đến 65535. Máy chủ không thể lắng nghe trên cổng {0}.",
+            ["Auto-start on launch"] = "Tự khởi chạy",
+            ["Start the server when the Editor opens this project."] = "Khởi chạy máy chủ khi Editor mở dự án này.",
+            ["Sync wait (ms)"] = "Chờ đồng bộ (ms)",
+            ["How long a request waits for its main-thread work before the server answers with a job id instead. The server does not go below 250 ms."] =
+                "Thời gian yêu cầu chờ xử lý trên luồng chính trước khi máy chủ trả về mã tác vụ (job id). Thời gian chờ tối thiểu là 250 ms.",
+            ["The server uses 250 ms, which is its floor."] = "Máy chủ dùng thời gian chờ tối thiểu là 250 ms.",
+            ["Detailed logs"] = "Nhật ký chi tiết",
+            ["Write every request and each start and stop step to the Console. Those lines come back to the agent through console_read_logs. Warnings and errors are written either way."] =
+                "Ghi từng yêu cầu và từng bước khởi chạy, dừng máy chủ vào Console. Tác nhân AI đọc được các dòng này qua console_read_logs. Cảnh báo và lỗi luôn được ghi dù bật hay tắt tùy chọn này.",
+            ["Keep Editor awake"] = "Giữ Editor hoạt động",
+            ["Without focus the Editor runs its main loop about every 100 ms, so calls that need it wait. The server wakes the loop while requests are queued. Turning this on keeps it awake for the whole session instead, at the cost of idle CPU."] =
+                "Khi không có tiêu điểm, Editor chạy vòng lặp chính khoảng mỗi 100 ms, nên các lệnh cần vòng lặp này phải chờ. Máy chủ đánh thức vòng lặp khi có yêu cầu trong hàng đợi. Bật tùy chọn này để giữ vòng lặp hoạt động suốt phiên, nhưng sẽ tốn CPU cả khi không có yêu cầu.",
+            ["Language"] = "Ngôn ngữ",
+            ["The language of this page. Tool descriptions and CLI output stay in English."] =
+                "Ngôn ngữ của trang này. Mô tả công cụ và đầu ra CLI vẫn dùng tiếng Anh.",
+            ["Follow the Editor"] = "Theo ngôn ngữ Editor",
+            ["These settings live in Unity's preferences folder and are shared by every project on this machine."] =
+                "Các cài đặt này được lưu trong thư mục tùy chọn của Unity và dùng chung cho mọi dự án trên máy này.",
+
+            // Help
+            ["Help"] = "Trợ giúp",
+            ["Getting started"] = "Bắt đầu sử dụng",
+            ["Documentation"] = "Tài liệu",
+            ["Troubleshooting"] = "Khắc phục sự cố",
+        };
+
         /// <summary>
         /// The translated entries. Public so the test can check that each translation carries the
         /// same {0}-style placeholders as its key; a translation with an index the key does not
@@ -118,15 +196,21 @@ namespace UnityMCP.Editor.Settings
         /// </summary>
         public static IReadOnlyDictionary<string, string> JapaneseEntries => Japanese;
 
+        /// <summary>The Vietnamese entries, exposed for the same translation checks.</summary>
+        public static IReadOnlyDictionary<string, string> VietnameseEntries => Vietnamese;
+
         /// <summary>Translates <paramref name="english"/> for the language the page is drawn in.</summary>
         public static string Tr(string english)
         {
-            if (Resolve() != SystemLanguage.Japanese)
+            switch (Resolve())
             {
-                return english;
+                case SystemLanguage.Japanese:
+                    return Japanese.TryGetValue(english, out var japanese) ? japanese : english;
+                case SystemLanguage.Vietnamese:
+                    return Vietnamese.TryGetValue(english, out var vietnamese) ? vietnamese : english;
+                default:
+                    return english;
             }
-
-            return Japanese.TryGetValue(english, out var translated) ? translated : english;
         }
 
         /// <summary>A label and its tooltip, both translated.</summary>
@@ -144,6 +228,8 @@ namespace UnityMCP.Editor.Settings
                     return SystemLanguage.English;
                 case McpUiLanguage.Japanese:
                     return SystemLanguage.Japanese;
+                case McpUiLanguage.Vietnamese:
+                    return SystemLanguage.Vietnamese;
                 default:
                     return EditorLanguage();
             }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Settings/McpSettingsProvider.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Settings/McpSettingsProvider.cs
@@ -32,6 +32,7 @@ namespace UnityMCP.Editor.Settings
 
         private const string GuideUrlEnglish = "https://unity-mcp.shiranui-isuzu.dev/en/";
         private const string GuideUrlJapanese = "https://unity-mcp.shiranui-isuzu.dev/";
+        private const string GuideUrlVietnamese = "https://unity-mcp.shiranui-isuzu.dev/vi/";
         private const string RepositoryUrl = "https://github.com/isuzu-shiranui/UnityMCP";
         private const string TroubleshootingUrlEnglish = RepositoryUrl + "/blob/main/docs/en/troubleshooting.md";
         private const string TroubleshootingUrlJapanese = RepositoryUrl + "/blob/main/docs/troubleshooting.md";
@@ -589,7 +590,7 @@ namespace UnityMCP.Editor.Settings
             settings.uiLanguage = EditorGUILayout.Popup(
                 McpEditorText.Content("Language", "The language of this page. Tool descriptions and CLI output stay in English."),
                 settings.uiLanguage,
-                new[] { McpEditorText.Tr("Follow the Editor"), "English", "日本語" });
+                new[] { McpEditorText.Tr("Follow the Editor"), "English", "日本語", "Tiếng Việt" });
 
             EditorGUIUtility.labelWidth = previousWidth;
             EditorGUI.indentLevel--;
@@ -615,10 +616,11 @@ namespace UnityMCP.Editor.Settings
             }
 
             var japanese = McpEditorText.Resolve() == SystemLanguage.Japanese;
+            var vietnamese = McpEditorText.Resolve() == SystemLanguage.Vietnamese;
 
             EditorGUI.indentLevel++;
-            DrawLink(McpEditorText.Tr("Getting started"), japanese ? GuideUrlJapanese : GuideUrlEnglish);
-            DrawLink(McpEditorText.Tr("Documentation"), RepositoryUrl);
+            DrawLink(McpEditorText.Tr("Getting started"), vietnamese ? GuideUrlVietnamese : japanese ? GuideUrlJapanese : GuideUrlEnglish);
+            DrawLink(McpEditorText.Tr("Documentation"), vietnamese ? RepositoryUrl + "/blob/main/README.vi.md" : RepositoryUrl);
             DrawLink(McpEditorText.Tr("Troubleshooting"), japanese ? TroubleshootingUrlJapanese : TroubleshootingUrlEnglish);
             EditorGUI.indentLevel--;
         }

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/McpEditorTextTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/McpEditorTextTests.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 
 using NUnit.Framework;
 
+using UnityEditor;
 using UnityEngine;
 
 using UnityMCP.Editor.Settings;
@@ -20,25 +21,38 @@ namespace UnityMCP.Editor.Tests
         private static readonly Regex Placeholder = new Regex(@"\{(\d+)\}");
 
         private int savedLanguage;
+        private bool hadEditorLocale;
+        private string savedEditorLocale;
 
         [SetUp]
         public void SaveLanguage()
         {
             this.savedLanguage = McpSettings.instance.uiLanguage;
+            this.hadEditorLocale = EditorPrefs.HasKey("Editor.kEditorLocale");
+            this.savedEditorLocale = EditorPrefs.GetString("Editor.kEditorLocale", string.Empty);
         }
 
         [TearDown]
         public void RestoreLanguage()
         {
             McpSettings.instance.uiLanguage = this.savedLanguage;
+            if (this.hadEditorLocale)
+            {
+                EditorPrefs.SetString("Editor.kEditorLocale", this.savedEditorLocale);
+            }
+            else
+            {
+                EditorPrefs.DeleteKey("Editor.kEditorLocale");
+            }
         }
 
-        [Test]
-        public void EveryTranslationCarriesTheSamePlaceholdersAsItsKey()
+        [TestCase(McpUiLanguage.Japanese)]
+        [TestCase(McpUiLanguage.Vietnamese)]
+        public void EveryTranslationCarriesTheSamePlaceholdersAsItsKey(McpUiLanguage language)
         {
             var wrong = new List<string>();
 
-            foreach (var entry in McpEditorText.JapaneseEntries)
+            foreach (var entry in Entries(language))
             {
                 if (!Indices(entry.Key).SetEquals(Indices(entry.Value)))
                 {
@@ -68,24 +82,74 @@ namespace UnityMCP.Editor.Tests
         }
 
         [Test]
-        public void AnUntranslatedStringDrawsInEnglish()
+        public void VietnameseDrawsTheTranslation()
         {
-            McpSettings.instance.uiLanguage = (int)McpUiLanguage.Japanese;
+            McpSettings.instance.uiLanguage = (int)McpUiLanguage.Vietnamese;
+
+            Assert.That(McpEditorText.Resolve(), Is.EqualTo(SystemLanguage.Vietnamese));
+            Assert.That(McpEditorText.Tr("Connection"), Is.EqualTo("Kết nối"));
+            Assert.That(string.Format(McpEditorText.Tr("Listening on port {0}"), 27400),
+                Is.EqualTo("Đang lắng nghe trên cổng 27400"));
+        }
+
+        [Test]
+        public void AutoFollowsTheVietnameseEditorLocale()
+        {
+            EditorPrefs.SetString("Editor.kEditorLocale", "Vietnamese");
+            McpSettings.instance.uiLanguage = (int)McpUiLanguage.Auto;
+
+            Assert.That(McpEditorText.Resolve(), Is.EqualTo(SystemLanguage.Vietnamese));
+            Assert.That(McpEditorText.Tr("Connection"), Is.EqualTo("Kết nối"));
+        }
+
+        [Test]
+        public void ExplicitVietnameseOverridesTheEditorLocale()
+        {
+            EditorPrefs.SetString("Editor.kEditorLocale", "Japanese");
+            McpSettings.instance.uiLanguage = (int)McpUiLanguage.Vietnamese;
+
+            Assert.That(McpEditorText.Resolve(), Is.EqualTo(SystemLanguage.Vietnamese));
+        }
+
+        [Test]
+        public void VietnameseTranslatesBothLabelAndTooltip()
+        {
+            McpSettings.instance.uiLanguage = (int)McpUiLanguage.Vietnamese;
+
+            var content = McpEditorText.Content("Auto-start on launch", "Start the server when the Editor opens this project.");
+
+            Assert.That(content.text, Is.EqualTo("Tự khởi chạy"));
+            Assert.That(content.tooltip, Is.EqualTo("Khởi chạy máy chủ khi Editor mở dự án này."));
+        }
+
+        [TestCase(McpUiLanguage.Japanese)]
+        [TestCase(McpUiLanguage.Vietnamese)]
+        public void AnUntranslatedStringDrawsInEnglish(McpUiLanguage language)
+        {
+            McpSettings.instance.uiLanguage = (int)language;
 
             const string absent = "A string that is deliberately not in the table.";
             Assert.That(McpEditorText.Tr(absent), Is.EqualTo(absent));
         }
 
-        [Test]
-        public void NoTranslationIsLeftAsItsKey()
+        [TestCase(McpUiLanguage.Japanese)]
+        [TestCase(McpUiLanguage.Vietnamese)]
+        public void NoTranslationIsLeftAsItsKey(McpUiLanguage language)
         {
-            var untranslated = McpEditorText.JapaneseEntries
-                .Where(e => e.Key == e.Value)
+            var untranslated = Entries(language)
+                .Where(e => string.IsNullOrWhiteSpace(e.Value) || e.Key == e.Value)
                 .Select(e => e.Key)
                 .Where(k => k != "MCP URL")
                 .ToList();
 
             Assert.That(untranslated, Is.Empty, "these entries add nothing over the English");
+        }
+
+        private static IReadOnlyDictionary<string, string> Entries(McpUiLanguage language)
+        {
+            return language == McpUiLanguage.Vietnamese
+                ? McpEditorText.VietnameseEntries
+                : McpEditorText.JapaneseEntries;
         }
 
         private static HashSet<string> Indices(string text)

--- a/scripts/attested/c83d0c6733acf11511707a0455c44278e683aba1846d0d0c3b7ef42876be8b89.json
+++ b/scripts/attested/c83d0c6733acf11511707a0455c44278e683aba1846d0d0c3b7ef42876be8b89.json
@@ -1,0 +1,9 @@
+{
+    "sourceHash":  "c83d0c6733acf11511707a0455c44278e683aba1846d0d0c3b7ef42876be8b89",
+    "total":  805,
+    "passed":  804,
+    "failed":  0,
+    "skipped":  1,
+    "unityVersion":  "6000.0.35f1",
+    "ranAt":  "2026-09-11T17:30:03.7565508Z"
+}

--- a/site/en/index.html
+++ b/site/en/index.html
@@ -14,6 +14,7 @@
 
   <div class="topbar">
     <a class="lang-link" href="../" hreflang="ja" lang="ja">日本語</a>
+    <a class="lang-link" href="../vi/" hreflang="vi" lang="vi">Tiếng Việt</a>
   </div>
 
   <header class="hero">
@@ -211,6 +212,7 @@
       <li><a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/README.en.md">README</a></li>
       <li><a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/docs/en/troubleshooting.md">Troubleshooting</a></li>
       <li><a href="../" hreflang="ja" lang="ja">日本語</a></li>
+      <li><a href="../vi/" hreflang="vi" lang="vi">Tiếng Việt</a></li>
     </ul>
     <p>Distributed under the MIT licence.</p>
   </footer>

--- a/site/index.html
+++ b/site/index.html
@@ -14,6 +14,7 @@
 
   <div class="topbar">
     <a class="lang-link" href="en/" hreflang="en" lang="en">English</a>
+    <a class="lang-link" href="vi/" hreflang="vi" lang="vi">Tiếng Việt</a>
   </div>
 
   <header class="hero">
@@ -211,6 +212,7 @@
       <li><a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/README.md">README</a></li>
       <li><a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/docs/troubleshooting.md">トラブルシューティング</a></li>
       <li><a href="en/" hreflang="en" lang="en">English</a></li>
+      <li><a href="vi/" hreflang="vi" lang="vi">Tiếng Việt</a></li>
     </ul>
     <p>MIT ライセンスで配布しています。</p>
   </footer>

--- a/site/style.css
+++ b/site/style.css
@@ -21,6 +21,10 @@
   --mono: "Cascadia Mono", "SF Mono", Consolas, "DejaVu Sans Mono", monospace;
 }
 
+html:lang(vi) {
+  --sans: -apple-system, "Segoe UI", system-ui, sans-serif;
+}
+
 *, *::before, *::after { box-sizing: border-box; }
 
 html { -webkit-text-size-adjust: 100%; }
@@ -67,6 +71,7 @@ code {
 .topbar {
   display: flex;
   justify-content: flex-end;
+  gap: 1rem;
   padding: 1.25rem 0 0;
 }
 

--- a/site/vi/index.html
+++ b/site/vi/index.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Bắt đầu sử dụng Unity MCP</title>
+<meta name="description" content="Hướng dẫn cài Unity MCP và kết nối Unity Editor với tác nhân AI. Hai cách cài đặt: không dùng dòng lệnh hoặc dùng công cụ dòng lệnh.">
+<link rel="stylesheet" href="../style.css">
+</head>
+<body>
+
+<div class="wrap">
+
+  <div class="topbar">
+    <a class="lang-link" href="../" hreflang="ja" lang="ja">日本語</a>
+    <a class="lang-link" href="../en/" hreflang="en" lang="en">English</a>
+  </div>
+
+  <header class="hero">
+    <h1>Bắt đầu sử dụng Unity MCP</h1>
+    <p class="tagline">Gói kết nối Unity Editor với tác nhân AI. Khi bạn đưa ra yêu cầu, tác nhân có thể đọc scene, thêm đối tượng và đọc lỗi trong Console. Gói hoạt động với Claude Code, Claude Desktop, Cursor, Codex, Gemini CLI và VS Code.</p>
+    <p class="headline">Một trong hai cách cài đặt hoàn toàn không dùng dòng lệnh. Bạn không cần mở terminal.</p>
+
+    <figure class="hero-shot">
+      <img src="../img/preferences.png" alt="Trang Unity MCP trong Preferences bằng tiếng Anh, với dòng đầu của mục Setup hiển thị Listening on port 27400 cùng dấu tích.">
+      <figcaption>Đây là màn hình khi thiết lập thành công; ảnh minh họa dùng giao diện tiếng Anh. Dấu <span class="live">✓</span> ở dòng đầu mục Setup (Thiết lập) cho biết Editor đang nhận kết nối.</figcaption>
+    </figure>
+  </header>
+
+  <section class="band">
+    <h2 class="band-label">Cần chuẩn bị</h2>
+    <div class="band-body">
+      <ul class="prereq">
+        <li>Unity Editor 2022.3 trở lên.</li>
+        <li>Git, tải từ <a href="https://git-scm.com/downloads">git-scm.com</a>. Unity dùng Git ở bước 1 để tải gói. Nếu thiếu Git, Package Manager sẽ dừng với lỗi "No 'git' executable was found". Bạn có thể giữ các tùy chọn mặc định của trình cài đặt. Nếu dùng VCC hoặc ALCOM theo hướng dẫn ở phần tiếp theo thì không cần Git.</li>
+        <li>Cách A dùng Claude Desktop vì định dạng tiện ích mở rộng này thuộc Claude Desktop. Ứng dụng có bản cho Windows và macOS. Trên Linux, hãy dùng cách B.</li>
+        <li>Dự án phải luôn mở trong Unity Editor khi sử dụng.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="band" id="vpm" aria-labelledby="vpm-title">
+    <h2 class="band-label" id="vpm-title">VCC và ALCOM</h2>
+    <div class="band-body">
+      <p>Nếu quản lý dự án bằng VRChat Creator Companion (VCC) hoặc ALCOM, hãy cài gói từ kho VPM. Cách này không cần Git. VCC và ALCOM tải gói dưới dạng zip, không gọi Git như Package Manager của Unity.</p>
+
+      <p>Liên kết bên dưới mở VCC hoặc ALCOM và yêu cầu bạn xác nhận thêm kho. Nếu dùng VCC, cần phiên bản 2.1.0 trở lên.</p>
+
+      <p><a href="vcc://vpm/addRepo?url=https%3A%2F%2Funity-mcp.shiranui-isuzu.dev%2Fvpm.json">Thêm kho Unity MCP</a></p>
+
+      <p class="code-label">Nếu liên kết không hoạt động, hãy thêm URL này thủ công</p>
+      <pre><code>https://unity-mcp.shiranui-isuzu.dev/vpm.json</code></pre>
+
+      <p class="aside">Trong VCC, chọn nút Add Repository trên thẻ Packages của trang Settings. Trong ALCOM, chọn nút Add Repository trên thẻ Repositories của trang Packages. Sau khi thêm kho, Unity MCP xuất hiện trong danh sách gói của dự án. Nếu cài theo cách này, hãy bỏ qua bước đầu của cả cách A và cách B rồi bắt đầu từ bước thứ hai.</p>
+    </div>
+  </section>
+
+  <section class="band">
+    <h2 class="band-label">Hai cách cài đặt</h2>
+    <div class="band-body">
+      <ul class="chooser">
+        <li>
+          <a href="#no-cli">
+            <span class="mark">A</span>
+            <span>
+              <strong>Cài đặt không dùng dòng lệnh</strong>
+              <span class="why">Chỉ cần Unity và Claude Desktop. Bạn không phải gõ lệnh.</span>
+            </span>
+          </a>
+        </li>
+        <li>
+          <a href="#cli">
+            <span class="mark">B</span>
+            <span>
+              <strong>Dùng dòng lệnh</strong>
+              <span class="why">Cài công cụ dòng lệnh để điều khiển Editor từ Claude Code, Cursor, Codex và các ứng dụng khác.</span>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="band" id="no-cli" aria-labelledby="no-cli-title">
+    <h2 class="band-label" id="no-cli-title">A. Không dùng dòng lệnh</h2>
+    <div class="band-body">
+      <p>Tổng cộng năm bước, không bước nào cần gõ lệnh.</p>
+
+      <ol class="steps">
+        <li>
+          <h3>Thêm gói vào Unity</h3>
+          <p>Trong Unity Editor, mở Window &gt; Package Manager. Nhấn nút + ở góc trên bên trái, chọn Add package from git URL, dán URL bên dưới rồi nhấn Add.</p>
+          <pre><code>https://github.com/isuzu-shiranui/UnityMCP.git?path=jp.shiranui-isuzu.unity-mcp</code></pre>
+          <figure class="shot">
+            <img src="../img/package-manager.png" alt="Package Manager của Unity với Unity MCP đã được thêm vào danh sách và đang được chọn.">
+            <figcaption>Sau khi thêm, Unity MCP xuất hiện trong danh sách của Package Manager.</figcaption>
+          </figure>
+          <p class="aside">Nếu đã cài bằng VCC hoặc ALCOM ở trên, bạn đã hoàn thành bước này. Hãy chuyển sang bước tiếp theo.</p>
+        </li>
+
+        <li>
+          <h3>Kiểm tra máy chủ đang chạy</h3>
+          <p>Mở cửa sổ Preferences của Editor và chọn Unity MCP trong danh sách bên trái. Trên Windows, Preferences nằm trong menu Edit. Khi dòng đầu của mục Setup hiển thị "✓ Listening on port", phía Unity đã sẵn sàng.</p>
+          <p class="aside">Để dùng tiếng Việt, mở Settings ngay trên trang này và chọn Tiếng Việt ở mục Language. Khi đó, dòng trạng thái trong mục Thiết lập sẽ là "✓ Đang lắng nghe trên cổng". Mô tả công cụ và đầu ra CLI vẫn dùng tiếng Anh.</p>
+          <p class="aside">Máy chủ tự khởi chạy khi mở dự án, bạn không cần khởi chạy thủ công. Cách cài đặt này không cần CLI ở dòng thứ hai.</p>
+        </li>
+
+        <li>
+          <h3>Tải tiện ích mở rộng</h3>
+          <p>Mở trang <a href="https://github.com/isuzu-shiranui/UnityMCP/releases">Releases</a> trên GitHub và tải tệp <code>isuzu-unity-cli.mcpb</code>.</p>
+          <figure class="shot">
+            <img src="../img/releases-assets.png" alt="Danh sách Assets trên trang GitHub Releases, gồm mười một tệp, trong đó có isuzu-unity-cli.mcpb.">
+            <figcaption><code>isuzu-unity-cli.mcpb</code> nằm trong danh sách Assets trên trang Releases. Nhấp vào tên tệp để tải xuống.</figcaption>
+          </figure>
+        </li>
+
+        <li>
+          <h3>Nhấp đúp để cài vào Claude Desktop</h3>
+          <p>Nhấp đúp vào tệp đã tải để Claude Desktop mở màn hình cài tiện ích mở rộng. Để trống trường tên dự án Unity nếu chỉ có một dự án Unity đang mở.</p>
+          <p class="aside">Tiện ích dùng chữ ký tự ký. Khi cài đặt, Claude Desktop ghi thông báo về tiện ích chưa được ký vào nhật ký. Điều này không ảnh hưởng đến hoạt động của tiện ích. Bạn cũng có thể kéo tệp vào cửa sổ, hoặc chọn tệp tại Settings &gt; Extensions &gt; Advanced settings &gt; Install Extension.</p>
+          <p class="aside">Nếu nhấp đúp khiến cửa sổ đóng ngay, đây là hiện tượng đã ghi nhận ở bản Claude Desktop từ Microsoft Store. Đổi phần mở rộng của tệp thành <code>.zip</code> rồi giải nén. Sau đó chọn Install Unpacked Extension trên cùng màn hình và chọn thư mục đã giải nén.</p>
+        </li>
+
+        <li>
+          <h3>Đưa ra yêu cầu</h3>
+          <p>Giữ dự án mở trong Unity Editor và viết yêu cầu trong Claude Desktop. Các công cụ không hoạt động khi Editor đã đóng.</p>
+        </li>
+      </ol>
+    </div>
+  </section>
+
+  <section class="band" id="cli" aria-labelledby="cli-title">
+    <h2 class="band-label" id="cli-title">B. Dùng dòng lệnh</h2>
+    <div class="band-body">
+      <p>Cài công cụ dòng lệnh <code>isuzu-unity-cli</code>. Các tệp thực thi là mã máy, nên không cần Node.js hay môi trường chạy .NET.</p>
+
+      <ol class="steps">
+        <li>
+          <h3>Thêm gói vào Unity</h3>
+          <p>Giống bước đầu của cách A. Mở Window &gt; Package Manager và dán URL bên dưới vào Add package from git URL.</p>
+          <pre><code>https://github.com/isuzu-shiranui/UnityMCP.git?path=jp.shiranui-isuzu.unity-mcp</code></pre>
+          <p class="aside">Nếu đã cài bằng VCC hoặc ALCOM ở trên, bạn đã hoàn thành bước này. Bạn có thể bật giao diện tiếng Việt tại Preferences &gt; Unity MCP &gt; Settings &gt; Language.</p>
+        </li>
+
+        <li>
+          <h3>Cài công cụ dòng lệnh</h3>
+          <p>Chạy một dòng lệnh trong terminal.</p>
+          <p class="code-label">Windows (PowerShell)</p>
+          <pre><code>irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 | iex</code></pre>
+          <p class="code-label">macOS và Linux</p>
+          <pre><code>curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh</code></pre>
+          <p class="aside">Nếu đã cài .NET SDK, bạn cũng có thể chạy <code>dotnet tool install -g IsuzuUnityCli</code>. Hoặc tải trực tiếp tệp thực thi từ <a href="https://github.com/isuzu-shiranui/UnityMCP/releases">Releases</a>. Nút Install (Cài đặt) trong Preferences &gt; Unity MCP của Editor cũng thực hiện việc cài CLI.</p>
+        </li>
+
+        <li>
+          <h3>Cài skill cho tác nhân AI</h3>
+          <p>Lệnh này cài skill cho Claude Code và Codex.</p>
+          <pre><code>isuzu-unity-cli setup</code></pre>
+        </li>
+
+        <li>
+          <h3>Đăng ký ứng dụng khách</h3>
+          <p>Một dòng lệnh đăng ký cả điểm cuối lẫn token. Bạn không cần tự xử lý token.</p>
+          <pre><code>isuzu-unity-cli setup --mcp --agent claude-code</code></pre>
+          <p class="aside"><code>--agent</code> chấp nhận <code>claude-code</code>, <code>claude-desktop</code>, <code>codex</code>, <code>cursor</code>, <code>gemini</code> hoặc <code>vscode</code>. Unity Editor phải đang chạy. Xem toàn bộ lệnh trong <a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/docs/en/cli.md">tài liệu CLI (tiếng Anh)</a>, và cấu hình từng ứng dụng trong <a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/docs/en/mcp-clients.md">Kết nối ứng dụng khách MCP (tiếng Anh)</a>.</p>
+        </li>
+      </ol>
+    </div>
+  </section>
+
+  <section class="band">
+    <h2 class="band-label">Các khả năng</h2>
+    <div class="band-body">
+      <ul class="can-do">
+        <li>Đọc cấu trúc phân cấp scene và tìm GameObject bạn cần.</li>
+        <li>Tạo GameObject, thêm component và thay đổi vị trí, góc xoay, tỷ lệ.</li>
+        <li>Đọc và ghi các thuộc tính được tuần tự hóa hiển thị trong Inspector.</li>
+        <li>Đọc lỗi và cảnh báo trong Console, hoặc đọc trực tiếp Editor.log.</li>
+        <li>Chụp Game view hoặc Scene view.</li>
+        <li>Đọc và thay đổi giá trị hiện tại của material.</li>
+        <li>Bắt đầu và dừng Play Mode.</li>
+      </ul>
+      <p>Công cụ Timeline chỉ xuất hiện khi cài gói Timeline; công cụ Recorder cần cả Recorder lẫn Timeline; công cụ kiểm thử cần Test Framework. Xem danh sách đầy đủ trong <a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/docs/en/tools.md">tài liệu công cụ (tiếng Anh)</a>.</p>
+    </div>
+  </section>
+
+  <section class="band">
+    <h2 class="band-label">Nếu không hoạt động</h2>
+    <div class="band-body">
+      <ul class="trouble-list">
+        <li class="trouble-item">
+          <h3>Unity Editor chưa mở</h3>
+          <p>Mọi công cụ đều thao tác trên Unity Editor đang chạy, nên sẽ không có phản hồi khi Editor đã đóng. Mở lại dự án và kiểm tra dấu ✓ ở dòng đầu mục Setup (Thiết lập) trong Preferences &gt; Unity MCP.</p>
+        </li>
+        <li class="trouble-item">
+          <h3>Nhiều dự án đang mở</h3>
+          <p>Khi nhiều Unity Editor cùng chạy, tiện ích chưa biết cần kết nối dự án nào. Điền tên trên thanh tiêu đề của Editor vào trường tên dự án trong cài đặt tiện ích. Bạn cũng có thể dùng Product Name trong Player Settings. Nếu cả hai tên vẫn khớp nhiều Editor, hãy đóng các Editor còn lại để chọn đúng dự án.</p>
+          <a class="more" href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/docs/en/mcp-clients.md">Xem cấu hình từng ứng dụng khách (tiếng Anh)</a>
+        </li>
+        <li class="trouble-item">
+          <h3>Không thấy công cụ</h3>
+          <p>Thêm hoặc xóa gói làm thay đổi danh sách công cụ, nhưng ứng dụng khách không nhận được thông báo về thay đổi đó. Hãy kết nối lại ứng dụng khách đang dùng.</p>
+          <a class="more" href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/docs/en/troubleshooting.md">Xem cách khắc phục sự cố (tiếng Anh)</a>
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <footer class="foot">
+    <ul>
+      <li><a href="https://github.com/isuzu-shiranui/UnityMCP">Kho mã nguồn</a></li>
+      <li><a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/README.vi.md">README</a></li>
+      <li><a href="https://github.com/isuzu-shiranui/UnityMCP/blob/main/docs/en/troubleshooting.md">Khắc phục sự cố (tiếng Anh)</a></li>
+      <li><a href="../" hreflang="ja" lang="ja">日本語</a></li>
+      <li><a href="../en/" hreflang="en" lang="en">English</a></li>
+    </ul>
+    <p>Phân phối theo giấy phép MIT.</p>
+  </footer>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Adds Vietnamese to Unity MCP Preferences and provides a Vietnamese README and illustrated setup guide, so users can configure the package and follow installation instructions in their language.

## Changes

- Add **Tiếng Việt** to the language selector, with translated labels, tooltips and dialogs. Existing saved language selections remain valid; missing translations fall back to English.
- Add `README.vi.md` and `site/vi/index.html`, with language navigation and Vietnamese Help links in Preferences.
- Use a system font stack for the Vietnamese guide to keep tone marks correctly attached on Windows. Commands and API identifiers retain their original form; English technical references and screenshots are clearly identified.

## Requested revisions

Addresses the [maintainer's feedback](https://github.com/isuzu-shiranui/UnityMCP/pull/34#issuecomment-5637584621):

- Rebased onto `develop` and translated the five newly added Preferences entries.
- Removed `VietnameseCoversTheSameEntriesAsJapanese`. Tests still check fallback behavior and placeholder integrity without requiring complete Vietnamese coverage.
- Kept `.github/workflows/ci.yml` unchanged from `develop`, removed fixed tool counts from both Vietnamese pages, and brought the README in line with the current English version.

## Validation

- Unity 6000.0.35f1 EditMode: 804 passed, 0 failed, 1 skipped; all 12 localization cases passed. The generated attestation is included and passes the source-hash and pinned-version checks from CI.
- CLI: 380 tests passed on .NET SDK 10.0.100; formatting verification and the Release build with warnings as errors passed.
- All 11 package, source and documentation checks from `develop` CI passed locally.
- Documentation: UTF-8/NFC, local links, anchors and command/example consistency passed.
- Chromium: navigation, images and language switching passed at 1440px and 390px, including mobile dark mode, with no horizontal overflow.

The skipped Scene View right-drag test requires a GUI Editor. The NativeAOT platform matrix was not run locally.

To review the interface, select **Tiếng Việt** in Preferences > Unity MCP > Settings > Language, then open the guide or README from Help.
