### PR TITLE
fix: the Windows installer says why it could not verify a download

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -43,7 +43,7 @@ irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 |
 curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh
 ```
 
-You can also download a binary from GitHub Releases and verify it against `SHA256SUMS`. With the .NET SDK installed, `dotnet tool install -g IsuzuUnityCli` works too.
+You can also download a binary from GitHub Releases and verify it against `SHA256SUMS`. With the .NET 10 SDK installed, `dotnet tool install -g IsuzuUnityCli` works too.
 
 Then install the agent skill and register an MCP client:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 |
 curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh
 ```
 
-GitHub Releases から実行ファイルを直接ダウンロードして、`SHA256SUMS` で検証することもできます。.NET SDK があれば `dotnet tool install -g IsuzuUnityCli` でも入ります。
+GitHub Releases から実行ファイルを直接ダウンロードして、`SHA256SUMS` で検証することもできます。.NET 10 SDK があれば `dotnet tool install -g IsuzuUnityCli` でも入ります。
 
 続けて、エージェント用のスキルと MCP クライアントを登録します。
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -45,7 +45,7 @@ irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 |
 curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh
 ```
 
-Bạn cũng có thể tải tệp thực thi từ GitHub Releases và đối chiếu mã băm với `SHA256SUMS`. Nếu đã cài .NET SDK, bạn có thể dùng `dotnet tool install -g IsuzuUnityCli`.
+Bạn cũng có thể tải tệp thực thi từ GitHub Releases và đối chiếu mã băm với `SHA256SUMS`. Nếu đã cài .NET 10 SDK, bạn có thể dùng `dotnet tool install -g IsuzuUnityCli`.
 
 Sau đó cài skill cho tác nhân AI và đăng ký ứng dụng khách MCP:
 

--- a/install.ps1
+++ b/install.ps1
@@ -96,6 +96,41 @@ public static extern IntPtr SendMessageTimeout(
             [IntPtr]0xffff, 0x001A, [UIntPtr]::Zero, "Environment", 0x0002, 1000, [ref]$ignored)
     }
 
+    # Get-FileHash in Windows PowerShell 5.1 is a script-module function. A file it cannot read
+    # produces an error that this scope's $ErrorActionPreference does not reach, the call returns
+    # nothing, and the checksum comparison then fails with "You cannot call a method on a
+    # null-valued expression", which names neither the file nor the reason. Security software
+    # holds a freshly downloaded executable open while it scans it, so a sharing violation is
+    # waited out before it is reported. The managed SHA-256 that SHA256.Create() returns on .NET
+    # Framework is refused under the FIPS policy; the CSP implementation is not.
+    function Get-Sha256 {
+        param([string]$Path)
+
+        $reason = $null
+        for ($attempt = 1; $attempt -le 20; $attempt++) {
+            try {
+                $stream = [System.IO.File]::OpenRead($Path)
+            } catch {
+                $reason = if ($_.Exception.InnerException) { $_.Exception.InnerException } else { $_.Exception }
+                if ($reason -is [System.IO.FileNotFoundException] -or $reason -is [System.UnauthorizedAccessException]) {
+                    break
+                }
+                Start-Sleep -Milliseconds 500
+                continue
+            }
+
+            $sha = New-Object System.Security.Cryptography.SHA256CryptoServiceProvider
+            try {
+                return ([System.BitConverter]::ToString($sha.ComputeHash($stream)) -replace '-', '')
+            } finally {
+                $sha.Dispose()
+                $stream.Dispose()
+            }
+        }
+
+        throw "Could not read $Path to verify its checksum: $($reason.Message)"
+    }
+
     if (-not $Version) { $Version = $env:ISUZU_UNITY_CLI_VERSION }
     if (-not $Version) { $Version = "latest" }
     if ($Version -ne "latest" -and $Version -notmatch "^v") {
@@ -151,7 +186,7 @@ public static extern IntPtr SendMessageTimeout(
             throw "SHA256SUMS has no entry for $assetName. The release may be malformed."
         }
         $expectedHash = ($sumsLine -split '\s+')[0].ToUpperInvariant()
-        $actualHash = (Get-FileHash -Path $tempAsset -Algorithm SHA256).Hash.ToUpperInvariant()
+        $actualHash = Get-Sha256 -Path $tempAsset
         if ($actualHash -ne $expectedHash) {
             throw "Checksum mismatch for $assetName. Expected $expectedHash, got $actualHash. Aborting install."
         }

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `install.ps1` says why it could not read the downloaded executable, and waits for security
+  software that still has it open, instead of failing on Windows PowerShell 5.1 with "You cannot
+  call a method on a null-valued expression". ([#38](https://github.com/isuzu-shiranui/UnityMCP/issues/38))
+- The READMEs and the setup guide say that `dotnet tool install -g IsuzuUnityCli` needs the .NET 10
+  SDK. An older SDK cannot read the package and reports that it has no DotnetToolSettings.xml.
+
 ## [4.3.0] - 2026-09-12
 
 ### Breaking

--- a/jp.shiranui-isuzu.unity-mcp/README.md
+++ b/jp.shiranui-isuzu.unity-mcp/README.md
@@ -32,7 +32,7 @@ irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 |
 curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh
 ```
 
-or, with the .NET SDK installed:
+or, with the .NET 10 SDK installed:
 
 ```bash
 dotnet tool install -g IsuzuUnityCli

--- a/site/en/index.html
+++ b/site/en/index.html
@@ -149,7 +149,7 @@
           <pre><code>irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 | iex</code></pre>
           <p class="code-label">macOS and Linux</p>
           <pre><code>curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh</code></pre>
-          <p class="aside">With the .NET SDK installed, <code>dotnet tool install -g IsuzuUnityCli</code> works too. You can also download a binary directly from <a href="https://github.com/isuzu-shiranui/UnityMCP/releases">Releases</a>. The Install button under Preferences &gt; Unity MCP in the Editor does the same thing.</p>
+          <p class="aside">With the .NET 10 SDK installed, <code>dotnet tool install -g IsuzuUnityCli</code> works too. You can also download a binary directly from <a href="https://github.com/isuzu-shiranui/UnityMCP/releases">Releases</a>. The Install button under Preferences &gt; Unity MCP in the Editor does the same thing.</p>
         </li>
 
         <li>

--- a/site/index.html
+++ b/site/index.html
@@ -149,7 +149,7 @@
           <pre><code>irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 | iex</code></pre>
           <p class="code-label">macOS / Linux</p>
           <pre><code>curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh</code></pre>
-          <p class="aside">.NET SDK が入っている場合は <code>dotnet tool install -g IsuzuUnityCli</code> でも入ります。<a href="https://github.com/isuzu-shiranui/UnityMCP/releases">Releases</a> から実行ファイルを直接ダウンロードすることもできます。Editor の Preferences &gt; Unity MCP にある「インストール」ボタンからも入ります。</p>
+          <p class="aside">.NET 10 SDK が入っている場合は <code>dotnet tool install -g IsuzuUnityCli</code> でも入ります。<a href="https://github.com/isuzu-shiranui/UnityMCP/releases">Releases</a> から実行ファイルを直接ダウンロードすることもできます。Editor の Preferences &gt; Unity MCP にある「インストール」ボタンからも入ります。</p>
         </li>
 
         <li>

--- a/site/vi/index.html
+++ b/site/vi/index.html
@@ -150,7 +150,7 @@
           <pre><code>irm https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1 | iex</code></pre>
           <p class="code-label">macOS và Linux</p>
           <pre><code>curl -fsSL https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh | sh</code></pre>
-          <p class="aside">Nếu đã cài .NET SDK, bạn cũng có thể chạy <code>dotnet tool install -g IsuzuUnityCli</code>. Hoặc tải trực tiếp tệp thực thi từ <a href="https://github.com/isuzu-shiranui/UnityMCP/releases">Releases</a>. Nút Install (Cài đặt) trong Preferences &gt; Unity MCP của Editor cũng thực hiện việc cài CLI.</p>
+          <p class="aside">Nếu đã cài .NET 10 SDK, bạn cũng có thể chạy <code>dotnet tool install -g IsuzuUnityCli</code>. Hoặc tải trực tiếp tệp thực thi từ <a href="https://github.com/isuzu-shiranui/UnityMCP/releases">Releases</a>. Nút Install (Cài đặt) trong Preferences &gt; Unity MCP của Editor cũng thực hiện việc cài CLI.</p>
         </li>
 
         <li>


### PR DESCRIPTION
Fixes the two failures reported in #38.

- install.ps1 computes the checksum with SHA256CryptoServiceProvider over a stream it opens itself, instead of Get-FileHash. On Windows PowerShell 5.1 Get-FileHash returns nothing for a file it cannot read, without throwing, and the next line failed with "You cannot call a method on a null-valued expression". A sharing violation is retried for up to ten seconds; any other failure is reported with its reason.
- The READMEs (ja/en/vi), the setup guide (ja/en/vi) and the package README say dotnet tool install needs the .NET 10 SDK.

Tested on Windows PowerShell 5.1: the script parses, has no BOM and no non-ASCII bytes, the hash matches Get-FileHash, a file held for 2 s is read after the wait, a file held for 15 s is refused after 10 s with the sharing violation as the reason, and a missing file is refused at once.
