### PR TITLE
4.3.1: a CLI installed with winget is left to winget

### DIFF
--- a/.github/workflows/auto-build-release.yml
+++ b/.github/workflows/auto-build-release.yml
@@ -1,7 +1,7 @@
 name: Release
 
-# Tags, uploads the downloadable binaries and publishes the tool package when the version in the
-# Unity package's package.json changes on main.
+# Tags, uploads the downloadable binaries, publishes the tool package and submits the Windows
+# binary to winget when the version in the Unity package's package.json changes on main.
 #
 # The three halves are gated independently, on three separate questions: does the tag exist, does
 # the release carry its assets, is the version on NuGet. Gating all of them on the tag makes a
@@ -9,11 +9,16 @@ name: Release
 # nothing to do and exits green with the artifacts still missing. Each gate asks about the thing
 # it protects, so a partial release is resumable with workflow_dispatch.
 #
+# winget has a fourth gate, asked of microsoft/winget-pkgs by scripts/winget-due.sh once in `plan`
+# and again in the `winget` job right before it submits. It is kept out of the other three, so a
+# run with only the submission left builds nothing, and the submission runs after the release, so
+# a failure there never holds the release back and is resumed the same way.
+#
 # The binaries are NativeAOT, and native code can only be produced on its own operating system,
-# so the work is split across jobs: `plan` answers the three questions and runs the checks once,
-# `binaries` builds one RID per runner, and `release` collects them and publishes. The gates are
-# computed in `plan` and read by the other two through job outputs, so a re-run still asks the
-# same three questions.
+# so the work is split across jobs: `plan` answers the questions and runs the checks once,
+# `binaries` builds one RID per runner, `release` collects them and publishes, and `winget`
+# submits the published Windows binary. The gates are computed in `plan` and read by the later
+# jobs through job outputs, so a re-run still asks the same questions.
 on:
   push:
     branches:
@@ -33,6 +38,7 @@ jobs:
       tag_exists: ${{ steps.check-tag.outputs.exists }}
       need_assets: ${{ steps.work.outputs.need_assets }}
       need_nuget: ${{ steps.work.outputs.need_nuget }}
+      need_winget: ${{ steps.check-winget.outputs.needed }}
 
     steps:
       - name: Checkout repository
@@ -133,6 +139,23 @@ jobs:
           else
             echo "IsuzuUnityCli $VERSION is not on the registry."
             echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # winget offers a release once a pull request adding its manifest has been merged into
+      # microsoft/winget-pkgs. When GitHub gives no usable answer, the script fails rather than
+      # guess, and that reads as "not due" here so it cannot hold back the release; the submission
+      # is then left for a re-run with workflow_dispatch.
+      - name: Due for winget?
+        id: check-winget
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if DUE=$(bash scripts/winget-due.sh "$VERSION"); then
+            echo "needed=$DUE" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not tell whether $VERSION is due for winget, so this run does not submit it."
+            echo "needed=false" >> "$GITHUB_OUTPUT"
           fi
 
       # The three answers folded into the two questions the later jobs ask. A missing tag counts
@@ -605,4 +628,188 @@ jobs:
             else
               echo "- NuGet: already published, skipped"
             fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Submits the published Windows binary. wingetcreate builds the manifest from the one winget-pkgs
+  # already holds and writes this release's URL, hash and version into it. Running after the
+  # release, a token that has expired fails this job alone, and a re-run with workflow_dispatch
+  # submits once the token has been replaced.
+  winget:
+    needs: [plan, release]
+    if: ${{ !cancelled() && needs.plan.outputs.need_winget == 'true' && needs.release.result == 'success' }}
+    runs-on: windows-latest
+    environment: winget
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    # Each run asks winget-pkgs again right before it submits, and two runs asking at the same time
+    # would both find nothing there and submit the same version twice.
+    concurrency:
+      group: winget-submission
+      cancel-in-progress: false
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      VERSION: ${{ needs.plan.outputs.version }}
+      TAG: ${{ needs.plan.outputs.tag }}
+      PACKAGE: IsuzuShiranui.IsuzuUnityCli
+      # The token passes through wingetcreate, so the executable is pinned by its hash as well as
+      # its version. GitHub lists the digest beside each release asset.
+      WINGETCREATE_VERSION: v1.12.13.0
+      WINGETCREATE_SHA256: 24042bd37915805615e6cf969ac57c6439124c3fe85823327f5f3fb24bd9ffea
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Asked again: plan answered before this run's release, and another run may have submitted
+      # since.
+      - name: Still due?
+        id: due
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DUE=$(bash scripts/winget-due.sh "$VERSION")
+          echo "needed=$DUE" >> "$GITHUB_OUTPUT"
+
+      # wingetcreate asks for an interactive GitHub sign-in when it has no token, which a runner can
+      # only wait on, so the token is checked before anything uses it.
+      - name: The token can submit to winget-pkgs
+        if: steps.due.outputs.needed == 'true'
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if [ -z "$WINGET_TOKEN" ]; then
+            echo "WINGET_TOKEN is not set in the winget environment. scripts/README.md says how to create it."
+            exit 1
+          fi
+
+          HEADERS=$(mktemp)
+          STATUS=$(curl -s --connect-timeout 20 --max-time 60 -o /dev/null -D "$HEADERS" -w '%{http_code}' \
+            -H "Authorization: Bearer $WINGET_TOKEN" https://api.github.com/user || true)
+
+          case "$STATUS" in
+            200) ;;
+            401)
+              echo "GitHub refused WINGET_TOKEN: it has expired, been revoked, or is mistyped."
+              exit 1
+              ;;
+            *)
+              echo "GitHub answered '$STATUS' when WINGET_TOKEN was checked; re-run once it answers."
+              exit 1
+              ;;
+          esac
+
+          # Only a classic token reports its scopes, so a fine-grained one reads as having none.
+          SCOPES=$(tr -d '\r' < "$HEADERS" | sed -n 's/^x-oauth-scopes: *//Ip')
+
+          case ", $SCOPES," in
+            *", public_repo,"* | *", repo,"*)
+              echo "WINGET_TOKEN is a classic token with: $SCOPES"
+              ;;
+            *)
+              echo "WINGET_TOKEN reports the scopes '$SCOPES'. wingetcreate needs a classic token with public_repo."
+              exit 1
+              ;;
+          esac
+
+      # The published copy, which is the file winget downloads, rather than the artifact the release
+      # job uploaded.
+      - name: The published executable matches SHA256SUMS
+        id: published
+        if: steps.due.outputs.needed == 'true'
+        run: |
+          BASE="https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG"
+          curl -fsSL --connect-timeout 20 --max-time 300 -o published.exe "$BASE/isuzu-unity-cli-win-x64.exe"
+          curl -fsSL --connect-timeout 20 --max-time 60 -o SHA256SUMS "$BASE/SHA256SUMS"
+
+          EXPECTED=$(awk '$2 == "isuzu-unity-cli-win-x64.exe" { print $1 }' SHA256SUMS)
+          ACTUAL=$(sha256sum published.exe | cut -d' ' -f1)
+
+          if [ -z "$EXPECTED" ] || [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "The published executable hashes to $ACTUAL; SHA256SUMS says '$EXPECTED'."
+            exit 1
+          fi
+
+          echo "url=$BASE/isuzu-unity-cli-win-x64.exe" >> "$GITHUB_OUTPUT"
+          echo "sha256=$ACTUAL" >> "$GITHUB_OUTPUT"
+
+      - name: Get wingetcreate
+        if: steps.due.outputs.needed == 'true'
+        run: |
+          curl -fsSL --connect-timeout 20 --max-time 300 -o wingetcreate.exe \
+            "https://github.com/microsoft/winget-create/releases/download/$WINGETCREATE_VERSION/wingetcreate.exe"
+          ACTUAL=$(sha256sum wingetcreate.exe | cut -d' ' -f1)
+
+          if [ "$ACTUAL" != "$WINGETCREATE_SHA256" ]; then
+            echo "wingetcreate.exe hashes to $ACTUAL, not the pinned $WINGETCREATE_SHA256."
+            exit 1
+          fi
+
+      # The token goes through the environment variable wingetcreate reads, never onto its command
+      # line, which wingetcreate warns may be logged.
+      - name: Write the manifest
+        id: manifest
+        if: steps.due.outputs.needed == 'true'
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          URL: ${{ steps.published.outputs.url }}
+          SHA256: ${{ steps.published.outputs.sha256 }}
+        run: |
+          RELEASED=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json publishedAt --jq '.publishedAt[0:10]')
+
+          ./wingetcreate.exe update "$PACKAGE" \
+            --version "$VERSION" \
+            --urls "$URL|x64" \
+            --release-notes-url "https://github.com/$GITHUB_REPOSITORY/releases/tag/$TAG" \
+            --release-date "$RELEASED" \
+            --out manifests
+
+          shopt -s globstar nullglob
+          INSTALLERS=(manifests/**/"$PACKAGE".installer.yaml)
+
+          if [ "${#INSTALLERS[@]}" != "1" ]; then
+            echo "Expected one installer manifest under manifests/, found ${#INSTALLERS[@]}."
+            exit 1
+          fi
+
+          # wingetcreate downloads the installer again to hash it, so this compares the copy it saw.
+          RECORDED=$(sed -n 's/^ *InstallerSha256: *//p' "${INSTALLERS[0]}" | tr -d '\r' | tr 'A-F' 'a-f')
+
+          if [ "$RECORDED" != "$SHA256" ]; then
+            echo "The manifest records $RECORDED for the installer; the published file is $SHA256."
+            exit 1
+          fi
+
+          DIRECTORY=$(dirname "${INSTALLERS[0]}")
+
+          for file in "$DIRECTORY"/*.yaml; do
+            echo "::group::$file"
+            cat "$file"
+            echo "::endgroup::"
+          done
+
+          echo "directory=$DIRECTORY" >> "$GITHUB_OUTPUT"
+
+      - name: Submit
+        if: steps.due.outputs.needed == 'true'
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          DIRECTORY: ${{ steps.manifest.outputs.directory }}
+        run: |
+          ./wingetcreate.exe submit --no-open \
+            --prtitle "New version: $PACKAGE version $VERSION" \
+            "$DIRECTORY" | tee submit.log
+
+          PR=$(grep -o 'https://github.com/microsoft/winget-pkgs/pull/[0-9]*' submit.log | head -n 1 || true)
+
+          {
+            echo "## winget"
+            echo ""
+            echo "- Submitted $PACKAGE $VERSION: ${PR:-the pull request is named in the job log}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/isuzu-unity-cli/skills/isuzu-unity-cli/SKILL.md
+++ b/isuzu-unity-cli/skills/isuzu-unity-cli/SKILL.md
@@ -116,7 +116,10 @@ The CLI and the Unity package ship as one version. When a command prints a line 
 newer release is out, or a reply mentions version skew, `isuzu-unity-cli update` moves both: it
 replaces the CLI and retargets each project's package. It refuses the installs it cannot move - a
 `file:` working copy, a folder under `Packages/`, anything VCC or ALCOM manages - and names the
-step that does move them. `--dry-run` says what would change without changing it.
+step that does move them. A CLI installed with winget or as a dotnet tool is updated by that tool:
+`update` prints the command, and until the CLI has been updated it moves the packages only as far as
+the version the CLI runs, so run it again afterwards. `--dry-run` says what would change without
+changing it.
 
 ## The rest of it
 

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/CommandContext.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/CommandContext.cs
@@ -174,8 +174,23 @@ public sealed class CommandContext
             return;
         }
 
-        Err.WriteLine(
-            $"{tag} is out and this is {Program.Version()}. "
-            + "'isuzu-unity-cli update' installs it and lines the Unity package up with it.");
+        var install = CliInstall.Read(ExecutablePath);
+
+        if (install.ReplacesItself)
+        {
+            Err.WriteLine(
+                $"{tag} is out and this is {Program.Version()}. "
+                + "'isuzu-unity-cli update' installs it and lines the Unity package up with it.");
+            return;
+        }
+
+        Err.WriteLine($"{tag} is out and this is {Program.Version()}. Update this CLI with: {install.UpdateCommand}");
+
+        if (install.Channel is CliChannel.Winget)
+        {
+            Err.WriteLine(CliInstall.WingetDelay);
+        }
+
+        Err.WriteLine("Then 'isuzu-unity-cli update' lines the Unity package up with it.");
     }
 }

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/DoctorCommand.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/DoctorCommand.cs
@@ -39,7 +39,9 @@ public static class DoctorCommand
         var running = context.ReadDescriptors();
         var known = context.ReadAllDescriptors();
 
-        ReportExecutable(context);
+        var cli = CliInstall.Read(context.ExecutablePath);
+
+        ReportExecutable(cli, context);
 
         context.Out.WriteLine("Agents");
 
@@ -72,7 +74,7 @@ public static class DoctorCommand
         }
 
         context.Out.WriteLine();
-        ReportRelease(context);
+        ReportRelease(cli, context);
 
         context.Out.WriteLine("Running Editors");
 
@@ -127,10 +129,11 @@ public static class DoctorCommand
     /// own build passes its tests. Found by an agent hitting a bug that had already been fixed
     /// three versions earlier.
     /// </remarks>
-    private static void ReportExecutable(CommandContext context)
+    private static void ReportExecutable(CliInstall.Install cli, CommandContext context)
     {
         context.Out.WriteLine("Executable");
-        context.Out.WriteLine($"  [running]  {Environment.ProcessPath ?? "unknown"} ({Program.Version()})");
+        context.Out.WriteLine($"  [running]  {context.ExecutablePath} ({Program.Version()})");
+        context.Out.WriteLine($"  [channel]  installed {cli.Description}; update with: {cli.UpdateCommand}");
 
         var onPath = FirstOnPath();
 
@@ -138,7 +141,7 @@ public static class DoctorCommand
         {
             context.Out.WriteLine("  [absent]   no isuzu-unity-cli on PATH; the command name will not resolve");
         }
-        else if (!SamePath(onPath, Environment.ProcessPath))
+        else if (!SamePath(onPath, context.ExecutablePath))
         {
             var version = VersionOf(onPath);
 
@@ -247,7 +250,7 @@ public static class DoctorCommand
     /// turns a bad release into a broken machine, and 'upgrade --release' is the way back when
     /// one turns out to be.
     /// </remarks>
-    private static void ReportRelease(CommandContext context)
+    private static void ReportRelease(CliInstall.Install cli, CommandContext context)
     {
         string? tag;
 
@@ -266,10 +269,26 @@ public static class DoctorCommand
         }
 
         context.Out.WriteLine("Release");
-        context.Out.WriteLine(
-            $"  {tag} is out and this is {Program.Version()}. "
-            + "Install it with 'isuzu-unity-cli upgrade', and update the Unity package to match. "
-            + "'upgrade --release <tag>' goes back if one turns out to be broken.");
+
+        if (cli.ReplacesItself)
+        {
+            context.Out.WriteLine(
+                $"  {tag} is out and this is {Program.Version()}. "
+                + "Install it with 'isuzu-unity-cli upgrade', and update the Unity package to match. "
+                + "'upgrade --release <tag>' goes back if one turns out to be broken.");
+        }
+        else
+        {
+            context.Out.WriteLine($"  {tag} is out and this is {Program.Version()}. Update this CLI with: {cli.UpdateCommand}");
+
+            if (cli.Channel is CliChannel.Winget)
+            {
+                context.Out.WriteLine("  " + CliInstall.WingetDelay);
+            }
+
+            context.Out.WriteLine("  Then 'isuzu-unity-cli update' updates the Unity package to match.");
+        }
+
         context.Out.WriteLine();
     }
 

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/UpdateCommand.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/UpdateCommand.cs
@@ -22,6 +22,14 @@ public static class UpdateCommand
 {
     public static async Task<int> Run(ParsedArgs parsed, CommandContext context)
     {
+        var install = CliInstall.Read(context.ExecutablePath);
+
+        if (parsed.Option("release") is not null && !install.ReplacesItself)
+        {
+            context.Err.WriteLine(UpgradeCommand.ReleaseRefusal(install));
+            return 1;
+        }
+
         var tag = await Latest(context);
 
         if (tag is null)
@@ -35,6 +43,11 @@ public static class UpdateCommand
         var current = Program.Version();
         var version = tag.TrimStart('v', 'V');
         var behind = ReleaseCheck.IsNewer(tag, current);
+
+        // A copy another tool installed reaches the release only when that tool offers it, which
+        // for winget is after review. A package moved ahead of it in the meantime would be talking
+        // to an older CLI, so until then the packages go only as far as the version this CLI runs.
+        var held = behind && !install.ReplacesItself;
 
         context.Out.WriteLine(behind
             ? $"{tag} is out and this is {current}."
@@ -53,10 +66,14 @@ public static class UpdateCommand
         {
             context.Out.WriteLine("  none found. Open a project, or pass --project.");
         }
+        else if (held)
+        {
+            context.Out.WriteLine($"  moved to {current}, the version this CLI runs, until the CLI is updated.");
+        }
 
         foreach (var descriptor in projects)
         {
-            failed |= !UpdateProject(context, descriptor, version, parsed.HasFlag("dry-run"));
+            failed |= !UpdateProject(context, descriptor, held ? current : version, parsed.HasFlag("dry-run"));
         }
 
         context.Out.WriteLine();
@@ -68,14 +85,26 @@ public static class UpdateCommand
             return failed ? 1 : 0;
         }
 
+        if (held)
+        {
+            context.Out.WriteLine(
+                $"  installed {install.Description}, so it is not updated here. Update it with: {install.UpdateCommand}");
+
+            if (install.Channel is CliChannel.Winget)
+            {
+                context.Out.WriteLine("  " + CliInstall.WingetDelay);
+            }
+
+            context.Out.WriteLine($"  Then run 'isuzu-unity-cli update' again to move the Unity projects to {tag}.");
+            return failed ? 1 : 0;
+        }
+
         if (parsed.HasFlag("dry-run"))
         {
             context.Out.WriteLine($"  would install {tag}.");
             return failed ? 1 : 0;
         }
 
-        // Reused rather than reimplemented: it knows to refuse a dotnet tool install, which
-        // would otherwise end with two copies on the machine and the older one first on PATH.
         var upgrade = await UpgradeCommand.Run(Reparse(parsed), context);
 
         return upgrade != 0 || failed ? 1 : 0;
@@ -119,6 +148,14 @@ public static class UpdateCommand
         if (!install.Updatable)
         {
             context.Out.WriteLine($"  {name}: {Refusal(install)}");
+            return true;
+        }
+
+        // Moving a project back is never what update means. With a CLI another tool updates, the
+        // target is the version the CLI runs, and a project can already be past it.
+        if (install.Version is not null && ReleaseCheck.IsNewer(install.Version, version))
+        {
+            context.Out.WriteLine($"  {name}: already at {install.Version}, which is past {version}. Left as it is.");
             return true;
         }
 

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Commands/UpgradeCommand.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Commands/UpgradeCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Text;
 using IsuzuUnityCli.Cli;
+using IsuzuUnityCli.Discovery;
 
 namespace IsuzuUnityCli.Commands;
 
@@ -9,17 +10,25 @@ public static class UpgradeCommand
     public const string WindowsScriptUrl = "https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1";
     public const string UnixScriptUrl = "https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh";
 
-    public const string DotnetToolMessage = "Installed as a dotnet tool; run: dotnet tool update -g IsuzuUnityCli";
-
     public static async Task<int> Run(ParsedArgs parsed, CommandContext context)
     {
-        var toolDirectory = DotnetToolDirectory(context.ExecutablePath);
-        if (toolDirectory is not null)
+        var install = CliInstall.Read(context.ExecutablePath);
+
+        if (!install.ReplacesItself)
         {
-            // The installer writes to its own directory and would leave two copies behind.
-            context.Out.WriteLine(IsGlobalToolDirectory(toolDirectory)
-                ? DotnetToolMessage
-                : "Installed as a dotnet tool; run: dotnet tool update IsuzuUnityCli --tool-path " + QuotePath(toolDirectory));
+            if (parsed.Option("release") is not null)
+            {
+                context.Err.WriteLine(ReleaseRefusal(install));
+                return 1;
+            }
+
+            context.Out.WriteLine($"Installed {install.Description}; run: {install.UpdateCommand}");
+
+            if (install.Channel is CliChannel.Winget)
+            {
+                context.Out.WriteLine(CliInstall.WingetDelay);
+            }
+
             return 0;
         }
 
@@ -70,34 +79,10 @@ public static class UpgradeCommand
         }
     }
 
-    /// <summary>True when this executable lives in a dotnet tools directory, which owns its own updates.</summary>
-    public static bool IsDotnetTool(string executablePath) => DotnetToolDirectory(executablePath) is not null;
-
-    private static bool IsGlobalToolDirectory(string directory) =>
-        string.Equals(Path.GetFileName(directory), "tools", StringComparison.OrdinalIgnoreCase)
-        && string.Equals(Path.GetFileName(Path.GetDirectoryName(directory)), ".dotnet", StringComparison.OrdinalIgnoreCase);
-
-    private static string QuotePath(string path) => OperatingSystem.IsWindows()
-        ? "'" + path.Replace("'", "''", StringComparison.Ordinal) + "'"
-        : "'" + path.Replace("'", "'\\''", StringComparison.Ordinal) + "'";
-
-    private static string? DotnetToolDirectory(string executablePath)
-    {
-        var directory = Path.GetDirectoryName(Path.GetFullPath(executablePath));
-
-        while (!string.IsNullOrEmpty(directory))
-        {
-            if (IsGlobalToolDirectory(directory)
-                || Directory.Exists(Path.Combine(directory, ".store", "isuzuunitycli")))
-            {
-                return directory;
-            }
-
-            directory = Path.GetDirectoryName(directory);
-        }
-
-        return null;
-    }
+    /// <summary>Why --release does nothing for a copy another tool installed.</summary>
+    public static string ReleaseRefusal(CliInstall.Install install) =>
+        $"This CLI was installed {install.Description}, and --release works only for a copy the install script manages. "
+        + "Install that version with the tool that installed this one.";
 
     private static async Task<int> RunScript(string script, string? version, bool windows, CommandContext context)
     {

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Discovery/CliInstall.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Discovery/CliInstall.cs
@@ -1,0 +1,230 @@
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace IsuzuUnityCli.Discovery;
+
+/// <summary>Which tool put this executable where it is, which decides what may replace it.</summary>
+public enum CliChannel
+{
+    /// <summary>The install script, or a file copied into place. This CLI replaces it itself.</summary>
+    Direct,
+
+    /// <summary>A dotnet tool, which dotnet updates.</summary>
+    DotnetTool,
+
+    /// <summary>A winget portable package, which winget updates.</summary>
+    Winget,
+}
+
+/// <summary>
+/// Reads where this executable sits to find out which tool installed it.
+/// </summary>
+/// <remarks>
+/// A copy another tool installed is updated through that tool. The install script writes into a
+/// directory of its own, so over a dotnet tool it leaves a second copy behind and the older one
+/// stays first on PATH. winget keeps the hash of the file it installed and checks it before an
+/// upgrade or an uninstall, and refuses both for a file that has since been replaced.
+/// </remarks>
+public static class CliInstall
+{
+    public const string WingetPackageId = "IsuzuShiranui.IsuzuUnityCli";
+
+    public const string WingetUpgrade = "winget upgrade --id " + WingetPackageId + " -e";
+
+    /// <summary>Said beside the winget command, because the release notice comes from GitHub first.</summary>
+    public const string WingetDelay =
+        "winget offers a release only after its manifest has been reviewed and merged into winget-pkgs.";
+
+    /// <summary>How the executable was installed, and the command that updates it.</summary>
+    public sealed record Install(CliChannel Channel, string UpdateCommand)
+    {
+        /// <summary>Whether <c>upgrade</c> may replace the executable.</summary>
+        public bool ReplacesItself => Channel is CliChannel.Direct;
+
+        /// <summary>How it got here, worded to follow "installed".</summary>
+        public string Description => Channel switch
+        {
+            CliChannel.DotnetTool => "as a dotnet tool",
+            CliChannel.Winget => "with winget",
+            _ => "by the install script or copied into place",
+        };
+    }
+
+    /// <summary>Reads <paramref name="executablePath"/> and says which tool installed it.</summary>
+    public static Install Read(string executablePath) => Read(executablePath, UninstallRecords);
+
+    /// <param name="executablePath">The path this process was started by.</param>
+    /// <param name="wingetRecords">The file and link paths winget recorded for this package.</param>
+    public static Install Read(string executablePath, Func<IReadOnlyList<string>> wingetRecords)
+    {
+        var path = Path.GetFullPath(executablePath);
+        var toolDirectory = DotnetToolDirectory(path);
+
+        if (toolDirectory is not null)
+        {
+            return new Install(
+                CliChannel.DotnetTool,
+                IsGlobalToolDirectory(toolDirectory)
+                    ? "dotnet tool update -g IsuzuUnityCli"
+                    : "dotnet tool update IsuzuUnityCli --tool-path " + QuotePath(toolDirectory));
+        }
+
+        // winget puts a link on PATH, and on Windows a process started through a link reports the
+        // link's path. The file behind it is asked about as well, for a link made somewhere else.
+        var names = new List<string> { path };
+
+        if (LinkTarget(path) is { } target)
+        {
+            names.Add(target);
+        }
+
+        if (names.Any(InWingetFolder) || Recorded(names, wingetRecords()))
+        {
+            return new Install(CliChannel.Winget, WingetUpgrade);
+        }
+
+        return new Install(CliChannel.Direct, "isuzu-unity-cli update");
+    }
+
+    /// <summary>A folder winget chose: its folder of links, or the one it unpacks this package into.</summary>
+    /// <remarks>
+    /// Compared by folder name, which holds for a per-user install, a machine-wide one, and a
+    /// portable package root moved in winget's settings, which moves the package folder but keeps
+    /// its name.
+    /// </remarks>
+    private static bool InWingetFolder(string path)
+    {
+        var folder = Path.GetDirectoryName(path);
+
+        if (string.IsNullOrEmpty(folder))
+        {
+            return false;
+        }
+
+        var name = Path.GetFileName(folder);
+
+        return name.StartsWith(WingetPackageId + "_", StringComparison.OrdinalIgnoreCase)
+               || (string.Equals(name, "Links", StringComparison.OrdinalIgnoreCase)
+                   && string.Equals(
+                       Path.GetFileName(Path.GetDirectoryName(folder)), "WinGet", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Whether winget recorded one of <paramref name="names"/> as this package's file or its link.</summary>
+    private static bool Recorded(IReadOnlyList<string> names, IReadOnlyList<string> records)
+    {
+        foreach (var record in records)
+        {
+            string full;
+
+            try
+            {
+                full = Path.GetFullPath(record);
+            }
+            catch (ArgumentException)
+            {
+                continue;
+            }
+
+            // Compared without case, as Windows compares paths: the records exist only there, and
+            // the drive letter winget wrote need not match the one this process was started by.
+            if (names.Any(name => string.Equals(name, full, StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<string> UninstallRecords()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return [];
+        }
+
+        return ReadUninstallKeys();
+    }
+
+    /// <summary>The file and link paths winget wrote into this package's Uninstall keys.</summary>
+    [SupportedOSPlatform("windows")]
+    private static List<string> ReadUninstallKeys()
+    {
+        var paths = new List<string>();
+
+        foreach (var hive in new[] { Registry.CurrentUser, Registry.LocalMachine })
+        {
+            try
+            {
+                using var uninstall = hive.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall");
+
+                if (uninstall is null)
+                {
+                    continue;
+                }
+
+                foreach (var name in uninstall.GetSubKeyNames())
+                {
+                    if (!name.StartsWith(WingetPackageId + "_", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    using var entry = uninstall.OpenSubKey(name);
+
+                    foreach (var value in new[] { "TargetFullPath", "SymlinkFullPath" })
+                    {
+                        if (entry?.GetValue(value) is string recorded && recorded.Length > 0)
+                        {
+                            paths.Add(recorded);
+                        }
+                    }
+                }
+            }
+            catch (Exception e) when (e is System.Security.SecurityException or IOException or UnauthorizedAccessException)
+            {
+                // A key this user cannot read records nothing this process can act on.
+            }
+        }
+
+        return paths;
+    }
+
+    private static string? LinkTarget(string path)
+    {
+        try
+        {
+            return new FileInfo(path).ResolveLinkTarget(returnFinalTarget: true)?.FullName;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsGlobalToolDirectory(string directory) =>
+        string.Equals(Path.GetFileName(directory), "tools", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(Path.GetFileName(Path.GetDirectoryName(directory)), ".dotnet", StringComparison.OrdinalIgnoreCase);
+
+    private static string QuotePath(string path) => OperatingSystem.IsWindows()
+        ? "'" + path.Replace("'", "''", StringComparison.Ordinal) + "'"
+        : "'" + path.Replace("'", "'\\''", StringComparison.Ordinal) + "'";
+
+    private static string? DotnetToolDirectory(string executablePath)
+    {
+        var directory = Path.GetDirectoryName(executablePath);
+
+        while (!string.IsNullOrEmpty(directory))
+        {
+            if (IsGlobalToolDirectory(directory)
+                || Directory.Exists(Path.Combine(directory, ".store", "isuzuunitycli")))
+            {
+                return directory;
+            }
+
+            directory = Path.GetDirectoryName(directory);
+        }
+
+        return null;
+    }
+}

--- a/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/IsuzuUnityCli.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>isuzu-unity-cli</AssemblyName>
     <RootNamespace>IsuzuUnityCli</RootNamespace>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/isuzu-unity-cli/src/IsuzuUnityCli/Program.cs
+++ b/isuzu-unity-cli/src/IsuzuUnityCli/Program.cs
@@ -107,9 +107,9 @@ public static class Program
             }
 
             // After the command, so it is the last line the reader sees rather than something
-            // that pushes the answer up the terminal. doctor and update say it themselves in
-            // more detail, and saying it twice reads as two different releases.
-            if (parsed.Command is not ("doctor" or "update"))
+            // that pushes the answer up the terminal. doctor, update and upgrade say it themselves
+            // in more detail, and saying it twice reads as two different releases.
+            if (parsed.Command is not ("doctor" or "update" or "upgrade"))
             {
                 context.ReportNewRelease();
             }

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/CliInstallTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/CliInstallTests.cs
@@ -1,0 +1,134 @@
+using IsuzuUnityCli.Discovery;
+using Xunit;
+
+namespace IsuzuUnityCli.Tests;
+
+/// <summary>
+/// Which tool installed this executable. A copy winget installed has to be left to winget, which
+/// refuses to upgrade or uninstall a file that no longer has the hash it recorded.
+/// </summary>
+public sealed class CliInstallTests : IDisposable
+{
+    private const string WingetFolder = "IsuzuShiranui.IsuzuUnityCli_Microsoft.Winget.Source_8wekyb3d8bbwe";
+
+    private readonly string root = Path.Combine(Path.GetTempPath(), "cli-install-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(root, recursive: true);
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    private string Executable(string folder) =>
+        Path.Combine([root, .. folder.Split('/'), "isuzu-unity-cli.exe"]);
+
+    private static CliInstall.Install Read(string path, params string[] records) =>
+        CliInstall.Read(path, () => records);
+
+    [Theory]
+    [InlineData("AppData/Local/Microsoft/WinGet/Links")]
+    [InlineData("Program Files/WinGet/Links")]
+    public void AWingetLinkIsLeftToWinget(string folder)
+    {
+        var install = Read(Executable(folder));
+
+        Assert.Equal(CliChannel.Winget, install.Channel);
+        Assert.Equal("winget upgrade --id IsuzuShiranui.IsuzuUnityCli -e", install.UpdateCommand);
+        Assert.False(install.ReplacesItself);
+    }
+
+    [Theory]
+    [InlineData("AppData/Local/Microsoft/WinGet/Packages/" + WingetFolder)]
+    [InlineData("Program Files/WinGet/Packages/" + WingetFolder)]
+    [InlineData("portable/" + WingetFolder)]
+    public void TheFolderWingetUnpacksThisPackageIntoIsLeftToWinget(string folder)
+    {
+        Assert.Equal(CliChannel.Winget, Read(Executable(folder)).Channel);
+    }
+
+    [Theory]
+    [InlineData("tools/Links")]
+    [InlineData("AppData/Local/Microsoft/WinGet/Packages/IsuzuShiranui.IsuzuUnityCliPreview_Microsoft.Winget.Source_8wekyb3d8bbwe")]
+    [InlineData("AppData/Local/Microsoft/WinGet/Packages/IsuzuShiranui.IsuzuUnityCli.Beta_Microsoft.Winget.Source_8wekyb3d8bbwe")]
+    [InlineData("AppData/Local/Programs/isuzu-unity-cli")]
+    public void AnythingElseReplacesItself(string folder)
+    {
+        var install = Read(Executable(folder));
+
+        Assert.Equal(CliChannel.Direct, install.Channel);
+        Assert.True(install.ReplacesItself);
+    }
+
+    [Fact]
+    public void ACopyInstalledWithLocationIsFoundByTheRecordWingetKeeps()
+    {
+        // --location puts the file in a folder of the caller's choosing, so only the record says
+        // whose it is. winget may write the path in another case than the process reports.
+        var path = Executable("cli");
+
+        Assert.Equal(CliChannel.Direct, Read(path).Channel);
+        Assert.Equal(CliChannel.Winget, Read(path, path.ToUpperInvariant()).Channel);
+    }
+
+    [Fact]
+    public void ARecordOfAnotherFileSaysNothingAboutThisOne()
+    {
+        Assert.Equal(CliChannel.Direct, Read(Executable("cli"), Executable("other")).Channel);
+    }
+
+    [Fact]
+    public void ALinkIsJudgedByTheFileItPointsAt()
+    {
+        var target = Executable("WinGet/Packages/" + WingetFolder);
+        var link = Executable("bin");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+        Directory.CreateDirectory(Path.GetDirectoryName(link)!);
+        File.WriteAllText(target, "");
+
+        try
+        {
+            File.CreateSymbolicLink(link, target);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Windows creates a symbolic link only with Developer Mode on or from an elevated process.
+            return;
+        }
+
+        Assert.Equal(CliChannel.Winget, Read(link).Channel);
+    }
+
+    [Fact]
+    public void AGlobalDotnetToolIsUpdatedThroughDotnet()
+    {
+        var install = Read(Path.Combine("/home/u", ".dotnet", "tools", "isuzu-unity-cli"));
+
+        Assert.Equal(CliChannel.DotnetTool, install.Channel);
+        Assert.Equal("dotnet tool update -g IsuzuUnityCli", install.UpdateCommand);
+    }
+
+    [Fact]
+    public void OnlyAPathInsideDotnetToolsCountsAsADotnetTool()
+    {
+        Assert.Equal(CliChannel.DotnetTool, Read(Path.Combine("/home/u", ".dotnet", "tools", "store", "x", "isuzu-unity-cli")).Channel);
+        Assert.Equal(CliChannel.Direct, Read(Path.Combine("/usr", "local", "bin", "isuzu-unity-cli")).Channel);
+        Assert.Equal(CliChannel.Direct, Read(Path.Combine("/home/u", "tools", "isuzu-unity-cli")).Channel);
+    }
+
+    [Fact]
+    public void ACustomToolPathIsRecognizedFromItsPackageStore()
+    {
+        Directory.CreateDirectory(Path.Combine(root, ".store", "isuzuunitycli"));
+
+        var install = Read(Path.Combine(root, "isuzu-unity-cli"));
+
+        Assert.Equal(CliChannel.DotnetTool, install.Channel);
+        Assert.Contains("--tool-path", install.UpdateCommand);
+    }
+}

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/HousekeepingCommandTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/HousekeepingCommandTests.cs
@@ -262,6 +262,30 @@ public sealed class HousekeepingCommandTests
     }
 
     [Fact]
+    public async Task DoctorNamesTheToolThatUpdatesACopyWingetInstalled()
+    {
+        using var home = new TempHome();
+        var report = new StringWriter();
+
+        // Cancelled so the release check gives up instead of asking GitHub.
+        var context = new CommandContext
+        {
+            Out = report,
+            Err = new StringWriter(),
+            WorkingDirectory = home.Root,
+            ReadDescriptors = () => [],
+            ReadAllDescriptors = () => [],
+            ExecutablePath = home.At("AppData", "Local", "Microsoft", "WinGet", "Links", "isuzu-unity-cli.exe"),
+            Cancellation = new CancellationToken(canceled: true),
+        };
+
+        Assert.Equal(0, await Program.Run(["doctor"], context));
+        Assert.Contains(
+            "[channel]  installed with winget; update with: winget upgrade --id IsuzuShiranui.IsuzuUnityCli -e",
+            report.ToString());
+    }
+
+    [Fact]
     public async Task DoctorWarnsWhenAnEditorDidNotGetItsPreferredPort()
     {
         using var home = new TempHome();

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/UpdateCommandTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/UpdateCommandTests.cs
@@ -230,4 +230,131 @@ public sealed class ReleaseNoticeTests : IDisposable
 
         Assert.Equal("", error.ToString());
     }
+
+    [Fact]
+    public void ACopyWingetInstalledIsToldToUpdateThroughWinget()
+    {
+        Cached("v9.9.9", TimeSpan.FromMinutes(1));
+
+        var error = new StringWriter();
+        new CommandContext
+        {
+            Err = error,
+            ReleaseCachePath = cache,
+            ExecutablePath = Path.Combine(Path.GetTempPath(), "Microsoft", "WinGet", "Links", "isuzu-unity-cli.exe"),
+        }.ReportNewRelease();
+
+        Assert.Contains(CliInstall.WingetUpgrade, error.ToString());
+    }
+}
+
+/// <summary>
+/// The CLI half of update, over a copy another tool installed.
+/// </summary>
+/// <remarks>
+/// The release is read from a fresh cache, so the context can be cancelled before the run: should
+/// the channel be misread, upgrade's download of the real installer is refused at once and
+/// nothing on this machine is replaced.
+/// </remarks>
+public sealed class UpdateCommandTests : IDisposable
+{
+    private static readonly string WingetLink =
+        Path.Combine(Path.GetTempPath(), "Microsoft", "WinGet", "Links", "isuzu-unity-cli.exe");
+
+    private readonly string root = Path.Combine(Path.GetTempPath(), "mcp-update-" + Guid.NewGuid().ToString("N"));
+
+    private string Cache => Path.Combine(root, "latest-release.json");
+
+    public UpdateCommandTests()
+    {
+        Directory.CreateDirectory(root);
+        File.WriteAllLines(Cache, new[] { "v99.0.0", DateTimeOffset.UtcNow.ToString("o") });
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(root, recursive: true);
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    private (CommandContext Context, StringWriter Out) Context(string executablePath, params InstanceDescriptor[] running)
+    {
+        var output = new StringWriter();
+
+        return (new CommandContext
+        {
+            Out = output,
+            Err = new StringWriter(),
+            ReadDescriptors = () => running,
+            ExecutablePath = executablePath,
+            ReleaseCachePath = Cache,
+            Cancellation = new CancellationToken(canceled: true),
+        }, output);
+    }
+
+    /// <summary>A project whose manifest asks for the package at <paramref name="dependency"/>.</summary>
+    private InstanceDescriptor Project(string name, string dependency)
+    {
+        var packages = Path.Combine(root, name, "Packages");
+        Directory.CreateDirectory(packages);
+        File.WriteAllText(
+            Path.Combine(packages, "manifest.json"),
+            "{\n  \"dependencies\": {\n    \"" + PackageInstall.PackageId + "\": \"" + dependency + "\"\n  }\n}\n");
+
+        return new InstanceDescriptor { ProjectName = name, ProjectPath = Path.Combine(root, name, "Assets") };
+    }
+
+    private string? Dependency(string name)
+    {
+        using var manifest = System.Text.Json.JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(root, name, "Packages", "manifest.json")));
+
+        return manifest.RootElement.GetProperty("dependencies").GetProperty(PackageInstall.PackageId).GetString();
+    }
+
+    [Fact]
+    public async Task UntilWingetHasTheReleaseAProjectMovesOnlyAsFarAsTheCli()
+    {
+        var (context, output) = Context(WingetLink, Project("Behind", "0.0.1"), Project("Ahead", "98.0.0"));
+
+        Assert.Equal(0, await Program.Run(["update"], context));
+        Assert.Equal(Program.Version(), Dependency("Behind"));
+        Assert.Equal("98.0.0", Dependency("Ahead"));
+        Assert.Contains("'isuzu-unity-cli update' again", output.ToString());
+    }
+
+    [Fact]
+    public async Task ReleaseIsRefusedForACopyWingetInstalledBeforeAnyProjectIsTouched()
+    {
+        var (context, _) = Context(WingetLink, Project("Game", "0.0.1"));
+
+        Assert.Equal(1, await Program.Run(["update", "--release", "v4.2.0"], context));
+        Assert.Equal("0.0.1", Dependency("Game"));
+    }
+
+    [Fact]
+    public async Task ACopyWingetInstalledIsLeftToWinget()
+    {
+        var (context, output) = Context(
+            Path.Combine(Path.GetTempPath(), "Microsoft", "WinGet", "Links", "isuzu-unity-cli.exe"));
+
+        Assert.Equal(0, await Program.Run(["update"], context));
+        Assert.Contains(CliInstall.WingetUpgrade, output.ToString());
+    }
+
+    [Fact]
+    public async Task ADryRunOverADotnetToolNamesDotnetInsteadOfSayingItWouldInstall()
+    {
+        var (context, output) = Context(
+            Path.Combine(Path.GetTempPath(), ".dotnet", "tools", "isuzu-unity-cli.exe"));
+
+        Assert.Equal(0, await Program.Run(["update", "--dry-run"], context));
+        Assert.Contains("dotnet tool update -g IsuzuUnityCli", output.ToString());
+        Assert.DoesNotContain("would install", output.ToString());
+    }
 }

--- a/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/UpgradeCommandTests.cs
+++ b/isuzu-unity-cli/tests/IsuzuUnityCli.Tests/UpgradeCommandTests.cs
@@ -8,6 +8,11 @@ namespace IsuzuUnityCli.Tests;
 
 public sealed class UpgradeCommandTests
 {
+    // Given to every run of upgrade over a copy another tool installed. Should the channel be
+    // misread, the download of the real installer is refused at once, so nothing on this machine
+    // is replaced and no PATH is rewritten.
+    private static readonly CancellationToken Cancelled = new(canceled: true);
+
     [Fact]
     public async Task CustomToolPathGetsItsOwnUpdateCommandWithoutRunningInstaller()
     {
@@ -16,20 +21,11 @@ public sealed class UpgradeCommandTests
         var output = new StringWriter();
         try
         {
-            var context = new CommandContext { Out = output, Err = new StringWriter(), ExecutablePath = Path.Combine(directory, "isuzu-unity-cli") };
+            var context = new CommandContext { Out = output, Err = new StringWriter(), ExecutablePath = Path.Combine(directory, "isuzu-unity-cli"), Cancellation = Cancelled };
             Assert.Equal(0, await Program.Run(["upgrade"], context));
             Assert.Contains("--tool-path '" + directory + "'", output.ToString());
             Assert.DoesNotContain(" -g ", output.ToString());
         }
-        finally { Directory.Delete(directory, true); }
-    }
-
-    [Fact]
-    public void CustomToolPathIsRecognizedFromItsPackageStore()
-    {
-        var directory = Path.Combine(Path.GetTempPath(), "cli-upgrade-test-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path.Combine(directory, ".store", "isuzuunitycli"));
-        try { Assert.True(UpgradeCommand.IsDotnetTool(Path.Combine(directory, "isuzu-unity-cli"))); }
         finally { Directory.Delete(directory, true); }
     }
 
@@ -100,6 +96,7 @@ public sealed class UpgradeCommandTests
             Out = output,
             Err = new StringWriter(),
             ExecutablePath = Path.Combine(Path.GetTempPath(), ".dotnet", "tools", "isuzu-unity-cli.exe"),
+            Cancellation = Cancelled,
         };
 
         Assert.Equal(0, await Program.Run(["upgrade"], context));
@@ -107,12 +104,35 @@ public sealed class UpgradeCommandTests
     }
 
     [Fact]
-    public void OnlyAPathInsideDotnetToolsCountsAsADotnetTool()
+    public async Task AWingetCopyIsUpdatedThroughWingetRatherThanReplaced()
     {
-        Assert.True(UpgradeCommand.IsDotnetTool(Path.Combine("/home/u", ".dotnet", "tools", "isuzu-unity-cli")));
-        Assert.True(UpgradeCommand.IsDotnetTool(Path.Combine("/home/u", ".dotnet", "tools", "store", "x", "isuzu-unity-cli")));
-        Assert.False(UpgradeCommand.IsDotnetTool(Path.Combine("/usr", "local", "bin", "isuzu-unity-cli")));
-        Assert.False(UpgradeCommand.IsDotnetTool(Path.Combine("/home/u", "tools", "isuzu-unity-cli")));
+        var output = new StringWriter();
+        var context = new CommandContext
+        {
+            Out = output,
+            Err = new StringWriter(),
+            ExecutablePath = Path.Combine(Path.GetTempPath(), "Microsoft", "WinGet", "Links", "isuzu-unity-cli.exe"),
+            Cancellation = Cancelled,
+        };
+
+        Assert.Equal(0, await Program.Run(["upgrade"], context));
+        Assert.Contains("winget upgrade --id IsuzuShiranui.IsuzuUnityCli -e", output.ToString());
+    }
+
+    [Fact]
+    public async Task ReleaseIsRefusedForACopyWingetInstalledRatherThanIgnored()
+    {
+        var error = new StringWriter();
+        var context = new CommandContext
+        {
+            Out = new StringWriter(),
+            Err = error,
+            ExecutablePath = Path.Combine(Path.GetTempPath(), "Microsoft", "WinGet", "Links", "isuzu-unity-cli.exe"),
+            Cancellation = Cancelled,
+        };
+
+        Assert.Equal(1, await Program.Run(["upgrade", "--release", "v4.2.0"], context));
+        Assert.Contains("--release", error.ToString());
     }
 
     [Fact]

--- a/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
+++ b/jp.shiranui-isuzu.unity-mcp/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Changelog
 
-## [Unreleased]
+## [4.3.1] - 2026-09-12
+
+### Changed
+- A CLI installed with winget is left to winget, and one installed as a dotnet tool to
+  `dotnet tool update`. `upgrade` and `update` print that command instead of replacing the
+  executable, which would make winget refuse to upgrade or uninstall it, and refuse `--release`
+  rather than ignore it. Until the CLI has been updated that way, `update` moves each project's
+  package only as far as the version the CLI runs, so the two keep matching.
+- `doctor` says how the running CLI was installed and which command updates it, and the notice
+  after each command names the same command.
+- The Settings window also looks for the CLI where winget puts it: winget's folder of links, and
+  the package folder winget adds to PATH when it cannot create a link. An Editor started before
+  winget changed PATH does not find either on its own PATH.
 
 ### Fixed
+- `update --dry-run` said it would install the new release over a CLI installed as a dotnet tool.
+- The Settings window finds the CLI in a PATH entry written in double quotes.
 - `install.ps1` says why it could not read the downloaded executable, and waits for security
   software that still has it open, instead of failing on Windows PowerShell 5.1 with "You cannot
   call a method on a null-valued expression". ([#38](https://github.com/isuzu-shiranui/UnityMCP/issues/38))

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Core/McpHttpServer.cs
@@ -33,7 +33,7 @@ namespace UnityMCP.Editor.Core
         /// answer for an assembly that is not loaded from a package, and CI checks that it too
         /// stays in step.
         /// </remarks>
-        private const string FallbackVersion = "4.3.0";
+        private const string FallbackVersion = "4.3.1";
 
         internal static string ProtocolVersion
         {

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Settings/IsuzuCliLocator.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Settings/IsuzuCliLocator.cs
@@ -1,15 +1,19 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace UnityMCP.Editor.Settings
 {
     /// <summary>
-    /// Finds the <c>isuzu-unity-cli</c> executable the way a shell would, plus the directory the
-    /// install script uses, which a GUI-launched Editor may not have on its PATH.
+    /// Finds the <c>isuzu-unity-cli</c> executable the way a shell would, plus the directories winget
+    /// and the install script use, which a GUI-launched Editor may not have on its PATH.
     /// </summary>
     internal static class IsuzuCliLocator
     {
         public const string ExecutableName = "isuzu-unity-cli";
+
+        /// <summary>The folder winget unpacks the package into when it comes from winget's own source.</summary>
+        internal const string WingetPackageFolder = "IsuzuShiranui.IsuzuUnityCli_Microsoft.Winget.Source_8wekyb3d8bbwe";
 
         public const string InstallScriptUrlWindows = "https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.ps1";
         public const string InstallScriptUrlUnix = "https://raw.githubusercontent.com/isuzu-shiranui/UnityMCP/main/install.sh";
@@ -17,17 +21,9 @@ namespace UnityMCP.Editor.Settings
         public static bool TryFind(out string path)
         {
             var isWindows = Path.DirectorySeparatorChar == '\\';
-            var fileName = isWindows ? ExecutableName + ".exe" : ExecutableName;
 
-            var candidates = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty).Split(Path.PathSeparator);
-            foreach (var directory in candidates)
+            foreach (var candidate in Candidates(Environment.GetEnvironmentVariable, isWindows))
             {
-                if (directory.Length == 0)
-                {
-                    continue;
-                }
-
-                var candidate = Path.Combine(directory, fileName);
                 if (File.Exists(candidate))
                 {
                     path = candidate;
@@ -35,19 +31,72 @@ namespace UnityMCP.Editor.Settings
                 }
             }
 
-            var home = Environment.GetEnvironmentVariable(isWindows ? "USERPROFILE" : "HOME") ?? string.Empty;
-            var installed = isWindows
-                ? Path.Combine(Environment.GetEnvironmentVariable("LOCALAPPDATA") ?? string.Empty, "Programs", ExecutableName, fileName)
-                : Path.Combine(home, ".local", "bin", fileName);
-
-            if (installed.Length > fileName.Length && File.Exists(installed))
-            {
-                path = installed;
-                return true;
-            }
-
             path = null;
             return false;
+        }
+
+        /// <summary>Where the executable may be, in the order the first match is taken.</summary>
+        /// <remarks>
+        /// winget links the command into its folder of links when it can create a symbolic link, and
+        /// otherwise puts the package folder itself on PATH. Either folder reaches PATH with the
+        /// install, and an Editor started before that keeps the PATH it started with.
+        /// </remarks>
+        internal static List<string> Candidates(Func<string, string> environment, bool isWindows)
+        {
+            var fileName = isWindows ? ExecutableName + ".exe" : ExecutableName;
+            var candidates = new List<string>();
+
+            foreach (var entry in (environment("PATH") ?? string.Empty).Split(Path.PathSeparator))
+            {
+                // Windows accepts an entry in double quotes.
+                var directory = entry.Trim().Trim('"');
+
+                if (directory.Length == 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    candidates.Add(Path.Combine(directory, fileName));
+                }
+                catch (ArgumentException)
+                {
+                    // Not a path, and a shell skips it too.
+                }
+            }
+
+            if (isWindows)
+            {
+                var local = environment("LOCALAPPDATA");
+                var programFiles = environment("ProgramFiles");
+
+                AddUnder(candidates, local, fileName, "Microsoft", "WinGet", "Links");
+                AddUnder(candidates, programFiles, fileName, "WinGet", "Links");
+                AddUnder(candidates, local, fileName, "Microsoft", "WinGet", "Packages", WingetPackageFolder);
+                AddUnder(candidates, programFiles, fileName, "WinGet", "Packages", WingetPackageFolder);
+                AddUnder(candidates, local, fileName, "Programs", ExecutableName);
+            }
+            else
+            {
+                AddUnder(candidates, environment("HOME"), fileName, ".local", "bin");
+            }
+
+            return candidates;
+        }
+
+        /// <remarks>
+        /// A variable that is not set adds nothing. Combined anyway, it makes a relative path, which
+        /// File.Exists resolves against the Editor's working directory: the project.
+        /// </remarks>
+        private static void AddUnder(List<string> candidates, string root, string fileName, params string[] folders)
+        {
+            if (string.IsNullOrEmpty(root))
+            {
+                return;
+            }
+
+            candidates.Add(Path.Combine(root, Path.Combine(folders), fileName));
         }
 
         /// <summary>The shell command that installs the CLI, shown to the user and run by the Settings window.</summary>

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/IsuzuCliLocatorTests.cs
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/IsuzuCliLocatorTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using NUnit.Framework;
+
+using UnityMCP.Editor.Settings;
+
+namespace UnityMCP.Editor.Tests
+{
+    /// <summary>
+    /// Where the Settings window looks for the CLI. An Editor started before winget put its folder
+    /// of links on PATH does not find that folder on its own PATH.
+    /// </summary>
+    [TestFixture]
+    internal sealed class IsuzuCliLocatorTests
+    {
+        private static readonly string Root = Path.GetTempPath();
+
+        private static Func<string, string> Variables(Dictionary<string, string> values)
+        {
+            return name => values.TryGetValue(name, out var value) ? value : null;
+        }
+
+        [Test]
+        public void PathComesFirstThenWingetsFoldersThenTheInstallScriptsFolder()
+        {
+            var bin = Path.Combine(Root, "bin");
+            var local = Path.Combine(Root, "Local");
+            var programFiles = Path.Combine(Root, "Program Files");
+            var package = IsuzuCliLocator.WingetPackageFolder;
+
+            var candidates = IsuzuCliLocator.Candidates(Variables(new Dictionary<string, string>
+            {
+                ["PATH"] = bin,
+                ["LOCALAPPDATA"] = local,
+                ["ProgramFiles"] = programFiles,
+            }), isWindows: true);
+
+            Assert.That(candidates, Is.EqualTo(new[]
+            {
+                Path.Combine(bin, "isuzu-unity-cli.exe"),
+                Path.Combine(local, "Microsoft", "WinGet", "Links", "isuzu-unity-cli.exe"),
+                Path.Combine(programFiles, "WinGet", "Links", "isuzu-unity-cli.exe"),
+                Path.Combine(local, "Microsoft", "WinGet", "Packages", package, "isuzu-unity-cli.exe"),
+                Path.Combine(programFiles, "WinGet", "Packages", package, "isuzu-unity-cli.exe"),
+                Path.Combine(local, "Programs", "isuzu-unity-cli", "isuzu-unity-cli.exe"),
+            }));
+        }
+
+        [Test]
+        public void APathEntryInDoubleQuotesNamesTheFolderInside()
+        {
+            var bin = Path.Combine(Root, "quoted bin");
+
+            var candidates = IsuzuCliLocator.Candidates(
+                Variables(new Dictionary<string, string> { ["PATH"] = "\"" + bin + "\"" }),
+                isWindows: true);
+
+            Assert.That(candidates, Is.EqualTo(new[] { Path.Combine(bin, "isuzu-unity-cli.exe") }));
+        }
+
+        [Test]
+        public void AnEntryThatIsNotAPathDoesNotStopTheSearch()
+        {
+            var bin = Path.Combine(Root, "bin");
+
+            var candidates = IsuzuCliLocator.Candidates(
+                Variables(new Dictionary<string, string> { ["PATH"] = "a|<b>" + Path.PathSeparator + bin }),
+                isWindows: true);
+
+            Assert.That(candidates, Does.Contain(Path.Combine(bin, "isuzu-unity-cli.exe")));
+        }
+
+        [Test]
+        public void AVariableThatIsNotSetAddsNoRelativePath()
+        {
+            var candidates = IsuzuCliLocator.Candidates(
+                Variables(new Dictionary<string, string> { ["PATH"] = string.Empty, ["LOCALAPPDATA"] = string.Empty }),
+                isWindows: true);
+
+            Assert.That(candidates, Is.Empty);
+        }
+
+        [Test]
+        public void OutsideWindowsOnlyTheInstallScriptsFolderIsAdded()
+        {
+            var home = Path.Combine(Root, "home");
+
+            var candidates = IsuzuCliLocator.Candidates(
+                Variables(new Dictionary<string, string> { ["HOME"] = home }),
+                isWindows: false);
+
+            Assert.That(candidates, Is.EqualTo(new[] { Path.Combine(home, ".local", "bin", "isuzu-unity-cli") }));
+        }
+    }
+}

--- a/jp.shiranui-isuzu.unity-mcp/Editor/Tests/IsuzuCliLocatorTests.cs.meta
+++ b/jp.shiranui-isuzu.unity-mcp/Editor/Tests/IsuzuCliLocatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc98bfb02e604c88863d4a7b2d20a8bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/jp.shiranui-isuzu.unity-mcp/package.json
+++ b/jp.shiranui-isuzu.unity-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jp.shiranui-isuzu.unity-mcp",
   "displayName": "Unity MCP",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "author": {
     "name": "Shiranui_Isuzu",
     "url": "https://github.com/isuzu-shiranui"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -126,6 +126,45 @@ A policy on a private repository stays provisional for seven days and lapses if 
 published in that window; the window can be restarted from the same page. This repository is
 public, so the policy activates on the first successful publish.
 
+## Submitting to winget
+
+After the GitHub release is published, the `winget` job submits the Windows binary to
+[microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) as `IsuzuShiranui.IsuzuUnityCli`
+with wingetcreate. `winget-due.sh` decides whether a version is due:
+
+```sh
+GH_TOKEN=$(gh auth token) bash scripts/winget-due.sh 4.3.2
+```
+
+It prints `false` until winget-pkgs holds the package, because wingetcreate builds each manifest
+from the previous one and the first is submitted by hand. It also prints `false` for a prerelease,
+for a version already merged, and for a version with a pull request in any state, so a closed
+submission is not opened again on every push to main; such a version has to be submitted by hand.
+It exits 1 when GitHub does not give a usable answer, because a rate limit read as "not there"
+would submit the same version twice. `plan` reads that as "not due" so the release goes ahead, and
+the `winget` job asks again right before it submits.
+
+The first manifest has to be for 4.3.1 or later. An older CLI does not know it was installed with
+winget, so its `upgrade` and `update` replace the file winget installed, and winget then refuses to
+upgrade or uninstall it.
+
+The submission needs a token. Create it when the first manifest is submitted, so that it is in
+place for the first release after the merge:
+
+1. A personal access token (classic) with only the `public_repo` scope, and an expiry. wingetcreate
+   does not support fine-grained tokens. `public_repo` grants write access to every public
+   repository the account can push to, organisation repositories included, so a separate account
+   for this is worth considering.
+2. An environment named `winget` under Settings > Environments, with deployment branches limited to
+   `main`. A required reviewer would hold each submission until someone approves it.
+3. A secret `WINGET_TOKEN` in that environment, holding the token.
+
+The `winget` job checks the token before it uses it, and fails when the token is missing, expired,
+or not a classic token with `public_repo`. The job runs after the release, so the GitHub release and
+NuGet are not held back: replace the token and re-run the workflow from `main` with
+workflow_dispatch. The first pull request from an account to winget-pkgs is held until that account
+agrees to the Microsoft CLA.
+
 ## Once 4.0.0 is on the registries
 
 One manual step, not automated because it happens exactly once. Nothing installs the npm package

--- a/scripts/attested/06016aedb3bdeb7ce1440a4812cf04632494d66aa0320cdc7f9a2bd079528d25.json
+++ b/scripts/attested/06016aedb3bdeb7ce1440a4812cf04632494d66aa0320cdc7f9a2bd079528d25.json
@@ -1,0 +1,9 @@
+{
+    "sourceHash":  "06016aedb3bdeb7ce1440a4812cf04632494d66aa0320cdc7f9a2bd079528d25",
+    "total":  812,
+    "passed":  811,
+    "failed":  0,
+    "skipped":  1,
+    "unityVersion":  "6000.0.35f1",
+    "ranAt":  "2026-09-12T09:31:18.2836912Z"
+}

--- a/scripts/winget-due.sh
+++ b/scripts/winget-due.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Prints true when this version of the CLI is due for a pull request to microsoft/winget-pkgs,
+# false when it is not, and exits 1 when GitHub does not give a usable answer. Needs GH_TOKEN.
+#
+#   bash scripts/winget-due.sh 4.3.2
+#
+# Not due: a prerelease; a package winget-pkgs does not have yet, because wingetcreate builds each
+# manifest from the previous one and the first is submitted by hand; a version already merged; and
+# a version with a pull request in any state. Counting only open pull requests would submit a
+# closed one again on every push to main, so a version whose pull request was closed is left to be
+# submitted by hand.
+set -euo pipefail
+
+VERSION="${1:?usage: winget-due.sh <version>}"
+: "${GH_TOKEN:?GH_TOKEN is not set}"
+
+PACKAGE="IsuzuShiranui.IsuzuUnityCli"
+MANIFESTS="manifests/i/IsuzuShiranui/IsuzuUnityCli"
+REPOSITORY="https://api.github.com/repos/microsoft/winget-pkgs"
+
+case "$VERSION" in
+  *-*)
+    echo "$VERSION is a prerelease." >&2
+    echo false
+    exit 0
+    ;;
+esac
+
+BODY=$(mktemp)
+trap 'rm -f "$BODY"' EXIT
+
+# Writes the response to $BODY and prints its status, which is 000 when nothing came back.
+get() {
+  curl -s --connect-timeout 20 --max-time 60 -o "$BODY" -w '%{http_code}' \
+    -H "Authorization: Bearer $GH_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "$@" || true
+}
+
+# Only 200 and 404 are answers. A rate limit read as "not there" submits the same version twice.
+exists() {
+  local status
+  status=$(get "$REPOSITORY/contents/$1")
+
+  case "$status" in
+    200) return 0 ;;
+    404) return 1 ;;
+    *)
+      echo "GitHub answered '$status' for microsoft/winget-pkgs/$1." >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Reads a JSON array of pull requests and prints the first whose title names this package and
+# version. Each word of a title is compared without case and without a leading v or trailing dots,
+# so "IsuzuShiranui.IsuzuUnityCli v4.3.2" counts and a title naming 4.3.20 does not.
+submitted() {
+  jq -r --arg package "$PACKAGE" --arg version "$VERSION" '
+    def words: ascii_downcase | [splits("[^a-z0-9.]+")] | map(sub("^v(?=[0-9])"; "") | sub("[.]+$"; ""));
+    ($package | ascii_downcase) as $p
+    | [.[]
+       | (.title | words) as $w
+       | select(any($w[]; . == $p) and any($w[]; . == $version))
+       | "\(.html_url) (\(.state))"]
+    | first // empty'
+}
+
+if ! exists "$MANIFESTS"; then
+  echo "$PACKAGE is not in winget-pkgs yet. Its first manifest is submitted by hand." >&2
+  echo false
+  exit 0
+fi
+
+if exists "$MANIFESTS/$VERSION"; then
+  echo "$PACKAGE $VERSION is already in winget-pkgs." >&2
+  echo false
+  exit 0
+fi
+
+STATUS=$(get -G \
+  --data-urlencode "q=repo:microsoft/winget-pkgs is:pr in:title \"$PACKAGE\" \"$VERSION\"" \
+  "https://api.github.com/search/issues")
+
+if [ "$STATUS" != "200" ] || [ "$(jq -r .incomplete_results "$BODY")" != "false" ]; then
+  echo "GitHub's search answered '$STATUS' without a complete result." >&2
+  exit 1
+fi
+
+SUBMITTED=$(jq '.items' "$BODY" | submitted)
+
+# Search results can trail a pull request opened moments ago, which is when a second run asks, so
+# the newest hundred are read from the pull request list as well.
+if [ -z "$SUBMITTED" ]; then
+  STATUS=$(get "$REPOSITORY/pulls?state=all&sort=created&direction=desc&per_page=100")
+
+  if [ "$STATUS" != "200" ]; then
+    echo "GitHub answered '$STATUS' for the newest pull requests." >&2
+    exit 1
+  fi
+
+  SUBMITTED=$(submitted < "$BODY")
+fi
+
+if [ -n "$SUBMITTED" ]; then
+  echo "$PACKAGE $VERSION was already submitted: $SUBMITTED" >&2
+  echo false
+  exit 0
+fi
+
+echo "$PACKAGE $VERSION is due." >&2
+echo true

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "dev.shiranui-isuzu/unity-mcp",
   "title": "Unity MCP",
   "description": "Unity Editor automation for AI agents: scenes, prefabs, assets, shaders, Timeline, tests, builds.",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "repository": {
     "url": "https://github.com/isuzu-shiranui/UnityMCP",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "nuget",
       "identifier": "IsuzuUnityCli",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Prepares winget as the main install path for the Windows CLI. This release submits nothing to winget: the gate says no until the first manifest has been merged into microsoft/winget-pkgs by hand.

- `upgrade` and `update` read how the running CLI was installed. A copy winget installed (its folder of links, the folder it unpacks the package into, or a path it recorded in its Uninstall key) and a dotnet tool are no longer replaced. The command that updates them is printed instead, and `--release` is refused rather than ignored. winget refuses to upgrade or uninstall a portable package whose file has changed.
- Until such a CLI has been updated, `update` moves each project's package only as far as the version the CLI runs, and never moves one back.
- `doctor` names the channel, and the release notice names the matching command.
- `update --dry-run` no longer says it would install over a dotnet tool.
- The Settings window also looks where winget puts the CLI: its folder of links, and the package folder winget adds to PATH when it cannot create a link. A PATH entry in double quotes is read as the folder inside.
- The release workflow gains a `winget` job that runs after the release. It asks `scripts/winget-due.sh` again, checks `WINGET_TOKEN`, verifies the published executable against SHA256SUMS, pins wingetcreate by hash, writes the manifest, compares its installer hash and submits. A GitHub API failure while planning, or a bad token, cannot hold back the GitHub release or NuGet.
- Releases the #38 installer fix from #39.

Tested:
- CLI: `dotnet test` (419 passed), `dotnet format --verify-no-changes` and `dotnet build -warnaserror`. The channel tests include a real symbolic link. Tests that run `upgrade` or `update` use an already cancelled token; a copy read as installed directly exits 130 with that token and never downloads the installer.
- Editor: attested on 6000.0.35f1, 811 of 812 passed and 1 skipped.
- `scripts/winget-due.sh` against the live API: the package missing from winget-pkgs, a prerelease, a missing GH_TOKEN, a merged version, a version found through search, a version found only among the newest pull requests, and a version with none. Seven title forms were checked against the matcher, including `v4.3.2`, a lowercase id, and 4.3.20, which does not match.
- Draft manifests for the first submission pass `winget validate`.
- A fresh-context review of the diff. Its findings on version skew, the plan gate, where the token is checked, winget installs without a symbolic link, title matching and timeouts are addressed.
